### PR TITLE
Restrict GITHUB_TOKEN scope in workflow (least privilege)

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -5,6 +5,9 @@ on:
       - main
   pull_request:
 
+permissions:
+  contents: read
+
 jobs:
   check:
     name: Quality & security checks


### PR DESCRIPTION
## Summary
- Adds explicit `permissions: contents: read` at the root of `.github/workflows/main.yml`.
- Resolves CodeQL alerts `actions/missing-workflow-permissions` (#1, #2, #3) flagged in org-wide GitHub Advanced Security scan.

## Why
Without an explicit `permissions:` block, the default `GITHUB_TOKEN` inherits whatever the repo/org-wide default is - historically `read-write` on older orgs. The three jobs (`check`, `test`, `build`) only check out code and run `make`, so read-only is sufficient.

## Test plan
- [ ] Confirm all three jobs (check, test, build) still pass on this PR.
- [ ] Verify the three CodeQL alerts auto-close after merge.