### PR TITLE
Fix pool/token filter endpoints (silent data loss + empty results)

### DIFF
--- a/dexpaprika/new_endpoints_test.go
+++ b/dexpaprika/new_endpoints_test.go
@@ -27,7 +27,12 @@ func TestPoolsFilter(t *testing.T) {
 	if len(pool.Tokens) == 0 {
 		t.Fatal("Pool missing tokens")
 	}
-	t.Logf("Got %d filtered pools, first: %s", len(result.Results), pool.ID)
+	// Guard against the silent data loss this fix addresses: the filter endpoint
+	// returns timeframe-split volume, so VolumeUSD24h must be populated.
+	if pool.VolumeUSD24h == nil {
+		t.Fatal("Pool missing volume_usd_24h (filter endpoint should return it)")
+	}
+	t.Logf("Got %d filtered pools, first: %s (vol24h=%.0f)", len(result.Results), pool.ID, *pool.VolumeUSD24h)
 }
 
 func TestPoolsFilterMultipleParams(t *testing.T) {

--- a/dexpaprika/pools.go
+++ b/dexpaprika/pools.go
@@ -46,8 +46,13 @@ type Pool struct {
 	LastPriceChangeUSD24h *float64 `json:"last_price_change_usd_24h"`
 	Fee                   *float64 `json:"fee"`
 	Tokens                []Token  `json:"tokens"`
-	VolumeUSD7d           *float64 `json:"volume_usd_7d,omitempty"`
-	LiquidityUSD          *float64 `json:"liquidity_usd,omitempty"`
+	// VolumeUSD is returned by the pools list endpoint. The pools filter endpoint
+	// instead returns timeframe-split volume below (VolumeUSD24h/7d/30d); the unused
+	// fields are nil/zero depending on which endpoint produced this value.
+	VolumeUSD24h *float64 `json:"volume_usd_24h,omitempty"`
+	VolumeUSD7d  *float64 `json:"volume_usd_7d,omitempty"`
+	VolumeUSD30d *float64 `json:"volume_usd_30d,omitempty"`
+	LiquidityUSD *float64 `json:"liquidity_usd,omitempty"`
 }
 
 // PoolsResponse represents the response for the pools endpoint.

--- a/dexpaprika/tokens.go
+++ b/dexpaprika/tokens.go
@@ -230,6 +230,7 @@ type FilteredToken struct {
 	PriceUSD     *float64 `json:"price_usd,omitempty"`
 	VolumeUSD24h *float64 `json:"volume_usd_24h,omitempty"`
 	VolumeUSD7d  *float64 `json:"volume_usd_7d,omitempty"`
+	VolumeUSD30d *float64 `json:"volume_usd_30d,omitempty"`
 	LiquidityUSD *float64 `json:"liquidity_usd,omitempty"`
 	FDVUSD       *float64 `json:"fdv_usd,omitempty"`
 	Txns24h      *int     `json:"txns_24h,omitempty"`
@@ -237,8 +238,10 @@ type FilteredToken struct {
 }
 
 // TokenFilterResponse represents the response from the token filter endpoint.
+// The endpoint returns its rows under a "data" key (not "results"), so Results
+// is tagged accordingly to stay backward-compatible for callers using .Results.
 type TokenFilterResponse struct {
-	Results  []FilteredToken `json:"results"`
+	Results  []FilteredToken `json:"data"`
 	PageInfo PageInfo        `json:"page_info"`
 }
 


### PR DESCRIPTION
## Problem
`Pools.Filter()` and `Tokens.Filter()` silently returned wrong/empty data against the live API — Go's lenient `encoding/json` meant no error, just bad results:
- **Pool filter:** `VolumeUSD` was always `0` and the real 24h/30d volume was dropped.
- **Token filter:** `Results` was always empty.

## Root cause (verified live)
The filter endpoints diverged from the list endpoints and the structs weren't updated:
- `/pools/filter` returns `volume_usd_24h/_7d/_30d` + `liquidity_usd` and **no flat `volume_usd`** — but `Pool` only had `volume_usd` (+ `volume_usd_7d`).
- `/tokens/filter` returns rows under a **`data`** key, but `TokenFilterResponse.Results` was tagged `json:"results"`.

## Fix (backward-compatible)
- Add `volume_usd_24h` + `volume_usd_30d` to `Pool` (kept `PoolFilterResponse.Results []Pool` — no breaking type change).
- Retag `TokenFilterResponse.Results` to `json:"data"` (Go field name unchanged → callers using `.Results` keep compiling).
- Add `volume_usd_30d` to `FilteredToken`.
- Regression assertion: pool filter rows must carry `volume_usd_24h`.

## Verification
Ran the full suite against the **live API**: all pass. Token filter now returns rows (was empty); pool filter `vol24h` populated (was 0). `go vet` clean.

Part of the cross-SDK fix for the same drift (Python: dexpaprika-sdk-python#7). Refs coinpaprika/devrel#40.
