### PR TITLE
feat: advanced pool search (/frontend/v1)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,13 @@
 # Changelog
 
+## [Unreleased]
+
+### Added
+- **Advanced pool search**: `Pools.AdvancedSearch()` (global, `/frontend/v1/pools`) and `Pools.AdvancedSearchByNetwork()` (per-network, `/frontend/v1/networks/{network}/pools`) for rich pool discovery with filters, cursor pagination, and optional detailed token metrics
+- Canonical `SortBy`/`SortDir` options are translated to the backend's `order_by`/`sort` query parameters automatically
+- New types: `AdvancedSearchOptions`, `AdvancedSearchResponse`, `PoolRow`, `AdvancedToken`, `AdvancedTokenTimeframe`
+- All response metric fields are optional/nullable to tolerate fields the API may omit
+
 ## [1.4.0] - 2026-03-31
 
 ### Added

--- a/README.md
+++ b/README.md
@@ -358,6 +358,42 @@ filtered, err := client.Pools.Filter(ctx, "ethereum", &dexpaprika.PoolFilterOpti
 fmt.Printf("Found %d pools matching criteria\n", len(filtered.Results))
 ```
 
+### Advanced Pool Search
+
+```go
+// Search pools across every network via /frontend/v1/pools.
+// SortBy/SortDir are the canonical names; they are translated to the backend's
+// order_by/sort on the wire for you.
+minPrice := 0.5
+res, err := client.Pools.AdvancedSearch(ctx, &dexpaprika.AdvancedSearchOptions{
+    Limit:       10,
+    SortBy:      "volume_usd_24h", // sent as order_by
+    SortDir:     "desc",           // sent as sort
+    PriceUSDMin: &minPrice,
+    DexName:     "uniswap_v3",
+    Detailed:    true, // attach FDV + per-timeframe token metrics
+})
+fmt.Printf("Found %d pools (has_next_page=%v)\n", len(res.Results), res.HasNextPage)
+
+// Cursor pagination (this endpoint is cursor-based, not page-based):
+if res.HasNextPage && res.NextCursor != nil {
+    next, _ := client.Pools.AdvancedSearch(ctx, &dexpaprika.AdvancedSearchOptions{
+        Limit:   10,
+        SortBy:  "volume_usd_24h",
+        SortDir: "desc",
+        Cursor:  *res.NextCursor,
+    })
+    fmt.Printf("Next page: %d pools\n", len(next.Results))
+}
+
+// Scope the same search to a single network via /frontend/v1/networks/{network}/pools:
+ethRes, err := client.Pools.AdvancedSearchByNetwork(ctx, "ethereum", &dexpaprika.AdvancedSearchOptions{
+    Limit:   10,
+    SortBy:  "liquidity_usd",
+    SortDir: "desc",
+})
+```
+
 ### Top Tokens & Token Filtering
 
 ```go

--- a/dexpaprika/advanced_pool_search.go
+++ b/dexpaprika/advanced_pool_search.go
@@ -1,0 +1,263 @@
+package dexpaprika
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"net/http"
+)
+
+// AdvancedSearchOptions contains options for the advanced pool search endpoints
+// (GET /frontend/v1/pools and GET /frontend/v1/networks/{network}/pools).
+//
+// Sorting uses the canonical SortBy/SortDir field names on this surface. They are
+// translated to the wire parameters order_by and sort respectively before the
+// request goes out, so callers never deal with the backend's inverted naming.
+type AdvancedSearchOptions struct {
+	// Limit caps the number of results returned (defaults to the API default when 0).
+	Limit int
+	// Cursor is the opaque pagination token. Pass the NextCursor from a previous
+	// response to fetch the next page. This endpoint is cursor-based, not page-based.
+	Cursor string
+	// SortBy is the field to order by. One of: volume_usd_24h, volume_usd_7d,
+	// volume_usd_30d, liquidity_usd, txns_24h, price_usd, price_change_percentage_24h,
+	// created_at. Sent on the wire as order_by. Defaults to volume_usd_24h.
+	SortBy string
+	// SortDir is the sort direction, "asc" or "desc". Sent on the wire as sort.
+	// Defaults to desc.
+	SortDir string
+	// Detailed, when true, makes each token in a result carry its FDV and the
+	// per-timeframe metric blocks (1m, 5m, 15m, 30m, 1h, 6h, 24h).
+	Detailed bool
+
+	// Optional filters. Each is sent under the same name on the wire. Pointer fields
+	// are only included in the request when non-nil so the zero value stays meaningful.
+	Volume24hMin *float64
+	Volume24hMax *float64
+	Volume7dMin  *float64
+	Volume7dMax  *float64
+	LiquidityMin *float64
+	LiquidityMax *float64
+	Txns24hMin   *int
+
+	PriceUSDMin *float64
+	PriceUSDMax *float64
+
+	PriceChange24hMin *float64
+	PriceChange24hMax *float64
+
+	DexName       string
+	CreatedAfter  string
+	CreatedBefore string
+}
+
+// AdvancedTokenTimeframe holds the per-timeframe metrics attached to a token when
+// AdvancedSearchOptions.Detailed is true. Every field is a pointer because the API
+// may omit any of them (notably LastPriceUSDChange is frequently null).
+type AdvancedTokenTimeframe struct {
+	VolumeUSD          *float64 `json:"volume_usd,omitempty"`
+	Buys               *int     `json:"buys,omitempty"`
+	Sells              *int     `json:"sells,omitempty"`
+	Txns               *int     `json:"txns,omitempty"`
+	LastPriceUSDChange *float64 `json:"last_price_usd_change,omitempty"`
+}
+
+// AdvancedToken is a token as returned by the advanced pool search endpoints.
+//
+// In the non-detailed responses tokens carry only a subset of these fields
+// (id, chain, has_image), so every field beyond ID is optional. When Detailed is
+// requested the FDV and timeframe blocks are populated.
+type AdvancedToken struct {
+	ID          string   `json:"id"`
+	Name        string   `json:"name,omitempty"`
+	Symbol      string   `json:"symbol,omitempty"`
+	Chain       string   `json:"chain,omitempty"`
+	Decimals    *int     `json:"decimals,omitempty"`
+	AddedAt     string   `json:"added_at,omitempty"`
+	Status      string   `json:"status,omitempty"`
+	HasImage    *bool    `json:"has_image,omitempty"`
+	FDV         *float64 `json:"fdv,omitempty"`
+	TotalSupply *float64 `json:"total_supply,omitempty"`
+	Website     string   `json:"website,omitempty"`
+	Description string   `json:"description,omitempty"`
+
+	// Timeframe metric blocks, populated only when Detailed is true.
+	Minute1  *AdvancedTokenTimeframe `json:"1m,omitempty"`
+	Minute5  *AdvancedTokenTimeframe `json:"5m,omitempty"`
+	Minute15 *AdvancedTokenTimeframe `json:"15m,omitempty"`
+	Minute30 *AdvancedTokenTimeframe `json:"30m,omitempty"`
+	Hour1    *AdvancedTokenTimeframe `json:"1h,omitempty"`
+	Hour6    *AdvancedTokenTimeframe `json:"6h,omitempty"`
+	Day      *AdvancedTokenTimeframe `json:"24h,omitempty"`
+}
+
+// PoolRow is a single pool returned by the advanced pool search endpoints.
+//
+// Metric fields are pointers so a value the API drops stays distinguishable from a
+// genuine zero. This mirrors the lesson from the pool/token filter fix: never
+// hard-require a field the backend is allowed to omit.
+type PoolRow struct {
+	ID                   string   `json:"id"`
+	DexID                string   `json:"dex_id"`
+	DexName              string   `json:"dex_name"`
+	Chain                string   `json:"chain"`
+	Fee                  *float64 `json:"fee"`
+	CreatedAt            string   `json:"created_at"`
+	CreatedAtBlockNumber int64    `json:"created_at_block_number"`
+
+	PriceUSD        *float64 `json:"price_usd,omitempty"`
+	Transactions24h *int     `json:"transactions_24h,omitempty"`
+	VolumeUSD24h    *float64 `json:"volume_usd_24h,omitempty"`
+	VolumeUSD7d     *float64 `json:"volume_usd_7d,omitempty"`
+	VolumeUSD30d    *float64 `json:"volume_usd_30d,omitempty"`
+	LiquidityUSD    *float64 `json:"liquidity_usd,omitempty"`
+
+	PriceChangePercentage5m  *float64 `json:"price_change_percentage_5m,omitempty"`
+	PriceChangePercentage1h  *float64 `json:"price_change_percentage_1h,omitempty"`
+	PriceChangePercentage24h *float64 `json:"price_change_percentage_24h,omitempty"`
+
+	Tokens []AdvancedToken `json:"tokens"`
+}
+
+// AdvancedSearchResponse is the cursor-paginated response shape of the advanced
+// pool search endpoints.
+type AdvancedSearchResponse struct {
+	Results     []PoolRow `json:"results"`
+	HasNextPage bool      `json:"has_next_page"`
+	// NextCursor is nil on the final page; pass it back via AdvancedSearchOptions.Cursor
+	// to fetch the next page.
+	NextCursor *string `json:"next_cursor"`
+	// Query echoes the parameters the backend actually applied (using its wire names,
+	// e.g. order_by and sort). Kept as raw JSON so new echo fields never break decoding.
+	Query json.RawMessage `json:"query,omitempty"`
+}
+
+// buildAdvancedSearchQuery applies opts to the request, translating the canonical
+// SortBy/SortDir names to the wire parameters order_by/sort.
+func (o *AdvancedSearchOptions) apply(req *http.Request) {
+	if o == nil {
+		return
+	}
+	q := req.URL.Query()
+
+	if o.Limit > 0 {
+		q.Add("limit", fmt.Sprintf("%d", o.Limit))
+	}
+	if o.Cursor != "" {
+		q.Add("cursor", o.Cursor)
+	}
+	// Canonical -> wire translation. This is the inverse of intuition: the surface
+	// speaks sort_by/sort_dir, the backend speaks order_by/sort.
+	if o.SortBy != "" {
+		q.Add("order_by", o.SortBy)
+	}
+	if o.SortDir != "" {
+		q.Add("sort", o.SortDir)
+	}
+	if o.Detailed {
+		q.Add("detailed", "true")
+	}
+
+	if o.Volume24hMin != nil {
+		q.Add("volume_24h_min", fmt.Sprintf("%v", *o.Volume24hMin))
+	}
+	if o.Volume24hMax != nil {
+		q.Add("volume_24h_max", fmt.Sprintf("%v", *o.Volume24hMax))
+	}
+	if o.Volume7dMin != nil {
+		q.Add("volume_7d_min", fmt.Sprintf("%v", *o.Volume7dMin))
+	}
+	if o.Volume7dMax != nil {
+		q.Add("volume_7d_max", fmt.Sprintf("%v", *o.Volume7dMax))
+	}
+	if o.LiquidityMin != nil {
+		q.Add("liquidity_usd_min", fmt.Sprintf("%v", *o.LiquidityMin))
+	}
+	if o.LiquidityMax != nil {
+		q.Add("liquidity_usd_max", fmt.Sprintf("%v", *o.LiquidityMax))
+	}
+	if o.Txns24hMin != nil {
+		q.Add("txns_24h_min", fmt.Sprintf("%d", *o.Txns24hMin))
+	}
+	if o.PriceUSDMin != nil {
+		q.Add("price_usd_min", fmt.Sprintf("%v", *o.PriceUSDMin))
+	}
+	if o.PriceUSDMax != nil {
+		q.Add("price_usd_max", fmt.Sprintf("%v", *o.PriceUSDMax))
+	}
+	if o.PriceChange24hMin != nil {
+		q.Add("price_change_percentage_24h_min", fmt.Sprintf("%v", *o.PriceChange24hMin))
+	}
+	if o.PriceChange24hMax != nil {
+		q.Add("price_change_percentage_24h_max", fmt.Sprintf("%v", *o.PriceChange24hMax))
+	}
+	if o.DexName != "" {
+		q.Add("dex_name", o.DexName)
+	}
+	if o.CreatedAfter != "" {
+		q.Add("created_after", o.CreatedAfter)
+	}
+	if o.CreatedBefore != "" {
+		q.Add("created_before", o.CreatedBefore)
+	}
+
+	req.URL.RawQuery = q.Encode()
+}
+
+// AdvancedSearch searches pools across all networks via GET /frontend/v1/pools.
+//
+// It supports rich filtering, canonical SortBy/SortDir sorting, optional detailed
+// token metrics, and cursor pagination. Use the returned NextCursor (when
+// HasNextPage is true) as opts.Cursor on the next call to page through results.
+//
+// Example:
+//
+//	minPrice := 0.5
+//	res, err := client.Pools.AdvancedSearch(ctx, &dexpaprika.AdvancedSearchOptions{
+//	    Limit:       10,
+//	    SortBy:      "volume_usd_24h",
+//	    SortDir:     "desc",
+//	    PriceUSDMin: &minPrice,
+//	    DexName:     "uniswap_v3",
+//	    Detailed:    true,
+//	})
+func (s *PoolsService) AdvancedSearch(ctx context.Context, opts *AdvancedSearchOptions) (*AdvancedSearchResponse, error) {
+	req, err := s.client.NewRequest(http.MethodGet, "/frontend/v1/pools", nil)
+	if err != nil {
+		return nil, err
+	}
+	opts.apply(req)
+
+	var response AdvancedSearchResponse
+	r, err := s.client.Do(ctx, req, &response)
+	if err != nil {
+		return nil, err
+	}
+	defer r.Body.Close()
+
+	return &response, nil
+}
+
+// AdvancedSearchByNetwork searches pools on a single network via
+// GET /frontend/v1/networks/{network}/pools. It accepts the same options as
+// AdvancedSearch.
+func (s *PoolsService) AdvancedSearchByNetwork(ctx context.Context, networkID string, opts *AdvancedSearchOptions) (*AdvancedSearchResponse, error) {
+	if err := validateNetworkID(networkID); err != nil {
+		return nil, err
+	}
+
+	req, err := s.client.NewRequest(http.MethodGet, fmt.Sprintf("/frontend/v1/networks/%s/pools", networkID), nil)
+	if err != nil {
+		return nil, err
+	}
+	opts.apply(req)
+
+	var response AdvancedSearchResponse
+	r, err := s.client.Do(ctx, req, &response)
+	if err != nil {
+		return nil, err
+	}
+	defer r.Body.Close()
+
+	return &response, nil
+}

--- a/dexpaprika/advanced_pool_search_test.go
+++ b/dexpaprika/advanced_pool_search_test.go
@@ -1,0 +1,208 @@
+package dexpaprika
+
+import (
+	"context"
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+	"time"
+)
+
+// TestPools_AdvancedSearch_SortTranslation is the guard against the #1 trap on this
+// endpoint: callers pass canonical SortBy/SortDir, but the wire must carry order_by/sort.
+// It also confirms the raw backend names are NEVER leaked onto the query string.
+func TestPools_AdvancedSearch_SortTranslation(t *testing.T) {
+	var gotQuery map[string]string
+
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.URL.Path != "/frontend/v1/pools" {
+			t.Errorf("expected path /frontend/v1/pools, got %s", r.URL.Path)
+		}
+		gotQuery = map[string]string{}
+		for k := range r.URL.Query() {
+			gotQuery[k] = r.URL.Query().Get(k)
+		}
+		w.Header().Set("Content-Type", "application/json")
+		w.WriteHeader(http.StatusOK)
+		_, _ = w.Write([]byte(`{"results":[],"has_next_page":false,"next_cursor":null,"query":{}}`))
+	}))
+	defer server.Close()
+
+	client := NewClient(
+		WithBaseURL(server.URL),
+		WithRetryConfig(0, time.Millisecond, time.Millisecond),
+	)
+	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+	defer cancel()
+
+	minPrice := 0.5
+	_, err := client.Pools.AdvancedSearch(ctx, &AdvancedSearchOptions{
+		Limit:       3,
+		SortBy:      "volume_usd_24h",
+		SortDir:     "desc",
+		PriceUSDMin: &minPrice,
+		DexName:     "uniswap_v3",
+		Detailed:    true,
+	})
+	if err != nil {
+		t.Fatalf("AdvancedSearch returned error: %v", err)
+	}
+
+	// The canonical names must be translated to the wire names.
+	if gotQuery["order_by"] != "volume_usd_24h" {
+		t.Errorf("expected order_by=volume_usd_24h on the wire, got %q", gotQuery["order_by"])
+	}
+	if gotQuery["sort"] != "desc" {
+		t.Errorf("expected sort=desc on the wire, got %q", gotQuery["sort"])
+	}
+	// The raw canonical names must NOT leak onto the wire.
+	if _, ok := gotQuery["sort_by"]; ok {
+		t.Errorf("sort_by leaked onto the wire; it must be translated to order_by")
+	}
+	if _, ok := gotQuery["sort_dir"]; ok {
+		t.Errorf("sort_dir leaked onto the wire; it must be translated to sort")
+	}
+	// Filters pass through unchanged.
+	if gotQuery["price_usd_min"] != "0.5" {
+		t.Errorf("expected price_usd_min=0.5, got %q", gotQuery["price_usd_min"])
+	}
+	if gotQuery["dex_name"] != "uniswap_v3" {
+		t.Errorf("expected dex_name=uniswap_v3, got %q", gotQuery["dex_name"])
+	}
+	if gotQuery["detailed"] != "true" {
+		t.Errorf("expected detailed=true, got %q", gotQuery["detailed"])
+	}
+	if gotQuery["limit"] != "3" {
+		t.Errorf("expected limit=3, got %q", gotQuery["limit"])
+	}
+}
+
+// TestPools_AdvancedSearch_Live hits the real /frontend/v1/pools endpoint.
+func TestPools_AdvancedSearch_Live(t *testing.T) {
+	client := NewClient(WithRetryConfig(2, time.Second, 3*time.Second))
+	ctx, cancel := context.WithTimeout(context.Background(), 20*time.Second)
+	defer cancel()
+
+	minPrice := 0.5
+	res, err := client.Pools.AdvancedSearch(ctx, &AdvancedSearchOptions{
+		Limit:       5,
+		SortBy:      "volume_usd_24h",
+		SortDir:     "desc",
+		PriceUSDMin: &minPrice,
+		Detailed:    true,
+	})
+	if err != nil {
+		t.Fatalf("AdvancedSearch live returned error: %v", err)
+	}
+	if res == nil {
+		t.Fatal("AdvancedSearch returned nil response")
+	}
+	if len(res.Results) == 0 {
+		t.Fatal("AdvancedSearch returned zero results; expected a non-empty page")
+	}
+
+	// The price_usd_min filter must actually be honored by the backend.
+	for i, row := range res.Results {
+		if row.ID == "" {
+			t.Errorf("result %d has empty pool id", i)
+		}
+		if row.PriceUSD != nil && *row.PriceUSD < minPrice {
+			t.Errorf("result %d price_usd %.6f is below the requested minimum %.2f", i, *row.PriceUSD, minPrice)
+		}
+	}
+
+	// detailed=true should attach timeframe blocks to at least one token.
+	foundDetailed := false
+	for _, row := range res.Results {
+		for _, tok := range row.Tokens {
+			if tok.Day != nil || tok.Hour1 != nil {
+				foundDetailed = true
+			}
+		}
+	}
+	if !foundDetailed {
+		t.Error("detailed=true did not produce any per-timeframe token metric blocks")
+	}
+
+	// The query echo should reflect the translated wire name.
+	if len(res.Query) > 0 {
+		var echo map[string]any
+		if err := json.Unmarshal(res.Query, &echo); err != nil {
+			t.Errorf("failed to decode query echo: %v", err)
+		} else if echo["order_by"] != "volume_usd_24h" {
+			t.Errorf("query echo order_by = %v, expected volume_usd_24h", echo["order_by"])
+		}
+	}
+
+	t.Logf("AdvancedSearch returned %d pools, has_next_page=%v", len(res.Results), res.HasNextPage)
+}
+
+// TestPools_AdvancedSearchByNetwork_Live hits /frontend/v1/networks/{network}/pools
+// and verifies cursor pagination plus the per-network chain constraint.
+func TestPools_AdvancedSearchByNetwork_Live(t *testing.T) {
+	client := NewClient(WithRetryConfig(2, time.Second, 3*time.Second))
+	ctx, cancel := context.WithTimeout(context.Background(), 20*time.Second)
+	defer cancel()
+
+	const network = "ethereum"
+	res, err := client.Pools.AdvancedSearchByNetwork(ctx, network, &AdvancedSearchOptions{
+		Limit:   3,
+		SortBy:  "volume_usd_24h",
+		SortDir: "desc",
+	})
+	if err != nil {
+		t.Fatalf("AdvancedSearchByNetwork live returned error: %v", err)
+	}
+	if len(res.Results) == 0 {
+		t.Fatal("AdvancedSearchByNetwork returned zero results")
+	}
+	for i, row := range res.Results {
+		if row.Chain != network {
+			t.Errorf("result %d chain = %q, expected %q", i, row.Chain, network)
+		}
+	}
+
+	// Volume-desc ordering means each successive volume_usd_24h should not increase.
+	var prev *float64
+	for _, row := range res.Results {
+		if row.VolumeUSD24h == nil {
+			continue
+		}
+		if prev != nil && *row.VolumeUSD24h > *prev {
+			t.Errorf("results not sorted desc by volume_usd_24h: %.2f came after %.2f", *row.VolumeUSD24h, *prev)
+		}
+		prev = row.VolumeUSD24h
+	}
+
+	// Cursor pagination: if there is a next page, fetching it should yield fresh pools.
+	if res.HasNextPage && res.NextCursor != nil {
+		next, err := client.Pools.AdvancedSearchByNetwork(ctx, network, &AdvancedSearchOptions{
+			Limit:   3,
+			SortBy:  "volume_usd_24h",
+			SortDir: "desc",
+			Cursor:  *res.NextCursor,
+		})
+		if err != nil {
+			t.Fatalf("AdvancedSearchByNetwork (page 2) returned error: %v", err)
+		}
+		if len(next.Results) == 0 {
+			t.Error("second page returned zero results despite has_next_page=true")
+		}
+		if len(next.Results) > 0 && len(res.Results) > 0 && next.Results[0].ID == res.Results[0].ID {
+			t.Error("cursor pagination returned the same first pool as page one")
+		}
+	}
+}
+
+// TestPools_AdvancedSearch_Validation checks the per-network variant rejects an
+// empty network ID.
+func TestPools_AdvancedSearch_Validation(t *testing.T) {
+	client := NewClient()
+	ctx := context.Background()
+
+	_, err := client.Pools.AdvancedSearchByNetwork(ctx, "", &AdvancedSearchOptions{})
+	if err == nil || err.Error() != "network ID is required" {
+		t.Errorf("expected 'network ID is required' error, got: %v", err)
+	}
+}


### PR DESCRIPTION
## What this adds

Two new methods on `PoolsService` for the `/frontend/v1` pool search endpoints:

- `Pools.AdvancedSearch(ctx, opts)` -> `GET /frontend/v1/pools` (global, all networks)
- `Pools.AdvancedSearchByNetwork(ctx, network, opts)` -> `GET /frontend/v1/networks/{network}/pools`

Both take the same `AdvancedSearchOptions` and return `AdvancedSearchResponse`.

## The one trap: inverted sort names

The surface exposes canonical `SortBy` / `SortDir`. The backend wire is inverted: it wants `order_by` for the field and `sort` for the direction. The options struct translates `SortBy -> order_by` and `SortDir -> sort` before the request goes out, so callers never deal with the raw names. The unit test asserts the translation happens and that `sort_by` / `sort_dir` never leak onto the wire.

## Shape decisions

- **Cursor pagination, not page-based.** `Cursor` goes in, `NextCursor` + `HasNextPage` come out. Pass `NextCursor` back as `Cursor` to page through.
- **Every response metric field is a pointer/optional.** This endpoint drops fields depending on `detailed=` and on the per-network variant (where tokens come back as just `id`/`chain`/`has_image`). Same lesson as the earlier pool/token filter fix: hard-requiring a droppable field breaks decoding.
- **`detailed=true`** attaches `fdv` plus per-timeframe metric blocks (`1m`,`5m`,`15m`,`30m`,`1h`,`6h`,`24h`) to each token, modeled as `AdvancedToken` + `AdvancedTokenTimeframe`.
- **`query` echo** kept as `json.RawMessage` so new echo keys never break decoding.
- Filters mirror the wire names: `price_usd_min/max`, `volume_24h/7d_min/max`, `liquidity_usd_min/max`, `txns_24h_min`, `price_change_percentage_24h_min/max`, `dex_name`, `created_after/before`.

## New types

`AdvancedSearchOptions`, `AdvancedSearchResponse`, `PoolRow`, `AdvancedToken`, `AdvancedTokenTimeframe`.

## Verification

Ran live against `api.dexpaprika.com`:

- `go build ./...` -- clean
- `go vet ./...` -- clean
- `go test ./...` -- full suite green (24s)
- New tests (`TestPools_AdvancedSearch*`) pass live and assert: non-empty results, `price_usd_min` is honored, `detailed=true` produces per-timeframe token blocks, cursor pagination returns fresh pools on page 2, the per-network variant constrains `chain`, and the sort translation produces `order_by`/`sort` on the wire with no `sort_by`/`sort_dir` leak.

No merge intended -- leaving this for review.