### PR TITLE
Fix 410s: migrate pool/token list+filter methods to /search

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,22 @@
 # Changelog
 
+## [1.5.0] - 2026-06-30
+
+### Breaking Changes
+- **API CHANGE**: DexPaprika removed four REST endpoints (now HTTP 410) and replaced them with the unified search endpoints:
+  - `GET /networks/{network}/pools` and `GET /networks/{network}/pools/filter` -> `GET /networks/{network}/pools/search`
+  - `GET /networks/{network}/tokens/top` and `GET /networks/{network}/tokens/filter` -> `GET /networks/{network}/tokens/search`
+- `Pools.ListByNetwork()`, `Pools.Filter()`, `Tokens.GetTop()`, and `Tokens.Filter()` now target the search endpoints. Method signatures are unchanged.
+- The search endpoints are cursor-paginated and do not accept `page`. The `Page` option is still accepted for source compatibility but is no longer sent; use the new `Cursor` option (read from a response's `NextCursor`) to page.
+- Sorting now uses `order_by` (field) plus `sort` (direction). Filter methods no longer send `sort_by`/`sort_dir`. Legacy sort values and filter parameter names are mapped to canonical values automatically (the search endpoints reject legacy values with HTTP 400).
+- `Tokens.GetTop()` now returns the flat search row shape. `TopToken` is now an alias for `FilteredToken`; the legacy `name`, `symbol`, pool count, and nested timeframe metrics are no longer returned by the API. `TopTokenTimeMetrics` was removed.
+- `TokenFilterResponse` rows are now read from `results` (previously `data`).
+
+### Changed
+- Response types now expose cursor pagination: `PoolsResponse`, `PoolFilterResponse`, `TopTokensResponse`, and `TokenFilterResponse` carry `HasNextPage` and `NextCursor`. `ListByNetwork` exposes search rows via the existing `.Pools` field for backward compatibility.
+- Extended `Pool` with the search item fields `Transactions24h` and `PriceChangePercentage5m/1h/24h`.
+- Added `Cursor` to `ListOptions`, `PoolFilterOptions`, `TopTokensOptions`, and `TokenFilterOptions`.
+
 ## [1.4.0] - 2026-03-31
 
 ### Added

--- a/README.md
+++ b/README.md
@@ -98,12 +98,12 @@ func main() {
         fmt.Printf("  - %s (%s)\n", network.DisplayName, network.ID)
     }
     
-    // Get top trading pools from Ethereum network
-    // Note: The global Pools.List() method has been deprecated in API v1.3.0
-    // Use ListByNetwork() for specific networks instead
+    // Get top trading pools from Ethereum network.
+    // ListByNetwork targets the unified /pools/search endpoint. It is
+    // cursor-paginated and reports 24h volume in VolumeUSD24h (a pointer).
     pools, err := client.Pools.ListByNetwork(ctx, "ethereum", &dexpaprika.ListOptions{
         Limit:   5,
-        OrderBy: "volume_usd",
+        OrderBy: "volume_usd_24h",
         Sort:    "desc",
     })
     if err != nil {
@@ -112,10 +112,14 @@ func main() {
     
     fmt.Println("\nTop trading pools on Ethereum:")
     for _, pool := range pools.Pools {
-        fmt.Printf("  - %s on %s (Volume: $%.2f)\n", 
-            pool.DexName, 
-            pool.Chain, 
-            pool.VolumeUSD)
+        vol24h := 0.0
+        if pool.VolumeUSD24h != nil {
+            vol24h = *pool.VolumeUSD24h
+        }
+        fmt.Printf("  - %s on %s (24h Volume: $%.2f)\n",
+            pool.DexName,
+            pool.Chain,
+            vol24h)
     }
 }
 ```
@@ -142,12 +146,12 @@ func main() {
     ctx, cancel := context.WithTimeout(context.Background(), 10*time.Second)
     defer cancel()
 
-    // Get top pools with pagination from Ethereum network
-    // Note: Global pools endpoint deprecated in API v1.3.0
+    // Get top pools from Ethereum network.
+    // ListByNetwork uses the cursor-paginated /pools/search endpoint; Page is
+    // ignored, use the Cursor option to page through results.
     poolsOpts := &dexpaprika.ListOptions{
         Limit:   10,
-        Page:    0,
-        OrderBy: "volume_usd",
+        OrderBy: "volume_usd_24h",
         Sort:    "desc",
     }
     pools, err := client.Pools.ListByNetwork(ctx, "ethereum", poolsOpts)
@@ -346,25 +350,33 @@ pairPools, err := client.Tokens.GetPools(ctx, "ethereum", "0xtoken1_address", &d
 
 ### Pool Filtering
 
+`Pools.Filter` targets the unified `/pools/search` endpoint. It is cursor-paginated
+(`Cursor` / `NextCursor`), and legacy sort values are normalized automatically.
+
 ```go
 // Find high-volume pools on Ethereum
 vol := 100000.0
 filtered, err := client.Pools.Filter(ctx, "ethereum", &dexpaprika.PoolFilterOptions{
     Limit:        10,
     Volume24hMin: &vol,
-    SortBy:       "volume_24h",
+    SortBy:       "volume_usd_24h",
     SortDir:      "desc",
 })
-fmt.Printf("Found %d pools matching criteria\n", len(filtered.Results))
+fmt.Printf("Found %d pools matching criteria (more pages: %v)\n", len(filtered.Results), filtered.HasNextPage)
 ```
 
 ### Top Tokens & Token Filtering
+
+`Tokens.GetTop` and `Tokens.Filter` target the unified `/tokens/search` endpoint and
+return the flat row shape (`FilteredToken`): address, chain, price, volume, liquidity,
+FDV, transactions, and 24h price change. The API no longer returns token name/symbol
+here. Both are cursor-paginated.
 
 ```go
 // Get top tokens by volume
 topTokens, err := client.Tokens.GetTop(ctx, "ethereum", &dexpaprika.TopTokensOptions{
     Limit:   10,
-    OrderBy: "volume_24h",
+    OrderBy: "volume_usd_24h",
 })
 
 // Filter tokens by criteria

--- a/dexpaprika/new_endpoints_test.go
+++ b/dexpaprika/new_endpoints_test.go
@@ -74,10 +74,11 @@ func TestTokensGetTop(t *testing.T) {
 	if token.Address == "" {
 		t.Fatal("Token missing address")
 	}
-	if token.Symbol == "" {
-		t.Fatal("Token missing symbol")
+	// tokens/search no longer returns name/symbol; price_usd is still present.
+	if token.PriceUSD == nil {
+		t.Fatal("Token missing price_usd")
 	}
-	t.Logf("Top token: %s at $%.4f", token.Symbol, *token.PriceUSD)
+	t.Logf("Top token: %s at $%.4f", token.Address[:10], *token.PriceUSD)
 }
 
 func TestTokensGetTopWithSort(t *testing.T) {

--- a/dexpaprika/pagination.go
+++ b/dexpaprika/pagination.go
@@ -20,7 +20,15 @@ type PoolsPaginator struct {
 	secondToken string // Optional, for filtering token pairs
 	options     *ListOptions
 	currentResp *PoolsResponse
+	cursor      string // Cursor for the cursor-paginated network /pools/search endpoint
 	err         error
+}
+
+// isNetworkSearch reports whether this paginator fetches network pools via the
+// cursor-paginated /pools/search endpoint (as opposed to the page-based DEX-pool
+// or token-pool endpoints).
+func (p *PoolsPaginator) isNetworkSearch() bool {
+	return p.networkID != "" && p.dexID == "" && p.tokenID == ""
 }
 
 // NewPoolsPaginator creates a new paginator for pools
@@ -68,6 +76,12 @@ func (p *PoolsPaginator) HasNextPage() bool {
 		return false
 	}
 
+	// The network /pools/search endpoint is cursor-paginated and reports whether
+	// more pages exist directly.
+	if p.isNetworkSearch() {
+		return p.currentResp.HasNextPage
+	}
+
 	// Check if we've received fewer items than requested, indicating last page
 	if len(p.currentResp.Pools) < p.options.Limit {
 		return false
@@ -87,29 +101,32 @@ func (p *PoolsPaginator) GetNextPage(ctx context.Context) error {
 		return fmt.Errorf("no more pages")
 	}
 
-	// Increment page number if not the first page
-	if p.currentResp != nil {
-		p.options.Page++
-	}
-
 	var resp *PoolsResponse
 	var err error
 
 	// Determine which API endpoint to call based on the set parameters
-	if p.tokenID != "" {
-		// Token pools - use new TokenPoolsOptions struct
+	switch {
+	case p.tokenID != "":
+		// Token pools (page-based) - use new TokenPoolsOptions struct
+		if p.currentResp != nil {
+			p.options.Page++
+		}
 		tokenOpts := &TokenPoolsOptions{
 			ListOptions:            p.options,
 			AdditionalTokenAddress: p.secondToken,
 		}
 		resp, err = p.client.Tokens.GetPools(ctx, p.networkID, p.tokenID, tokenOpts)
-	} else if p.dexID != "" {
-		// DEX pools
+	case p.dexID != "":
+		// DEX pools (page-based)
+		if p.currentResp != nil {
+			p.options.Page++
+		}
 		resp, err = p.client.Pools.ListByDex(ctx, p.networkID, p.dexID, p.options)
-	} else if p.networkID != "" {
-		// Network pools
+	case p.networkID != "":
+		// Network pools (cursor-based /pools/search)
+		p.options.Cursor = p.cursor
 		resp, err = p.client.Pools.ListByNetwork(ctx, p.networkID, p.options)
-	} else {
+	default:
 		// No network specified - this was using the deprecated global endpoint
 		// Return an error to guide users to use network-specific pagination
 		err = fmt.Errorf("network ID is required for pools pagination. Use ForNetwork(networkID) to specify a network")
@@ -121,6 +138,16 @@ func (p *PoolsPaginator) GetNextPage(ctx context.Context) error {
 	}
 
 	p.currentResp = resp
+
+	// Track the cursor for the next page of a network search.
+	if p.isNetworkSearch() {
+		if resp != nil && resp.NextCursor != nil {
+			p.cursor = *resp.NextCursor
+		} else {
+			p.cursor = ""
+		}
+	}
+
 	return nil
 }
 

--- a/dexpaprika/pools.go
+++ b/dexpaprika/pools.go
@@ -46,27 +46,44 @@ type Pool struct {
 	LastPriceChangeUSD24h *float64 `json:"last_price_change_usd_24h"`
 	Fee                   *float64 `json:"fee"`
 	Tokens                []Token  `json:"tokens"`
-	// VolumeUSD is returned by the pools list endpoint. The pools filter endpoint
-	// instead returns timeframe-split volume below (VolumeUSD24h/7d/30d); the unused
-	// fields are nil/zero depending on which endpoint produced this value.
-	VolumeUSD24h *float64 `json:"volume_usd_24h,omitempty"`
-	VolumeUSD7d  *float64 `json:"volume_usd_7d,omitempty"`
-	VolumeUSD30d *float64 `json:"volume_usd_30d,omitempty"`
-	LiquidityUSD *float64 `json:"liquidity_usd,omitempty"`
+	// VolumeUSD/Transactions/LastPriceChangeUSD* are returned by the DEX-pools and
+	// token-pools endpoints. The /pools/search endpoint instead returns the
+	// timeframe-split and percentage-named fields below; whichever endpoint
+	// produced this value leaves the other set nil/zero.
+	VolumeUSD24h             *float64 `json:"volume_usd_24h,omitempty"`
+	VolumeUSD7d              *float64 `json:"volume_usd_7d,omitempty"`
+	VolumeUSD30d             *float64 `json:"volume_usd_30d,omitempty"`
+	LiquidityUSD             *float64 `json:"liquidity_usd,omitempty"`
+	Transactions24h          int      `json:"transactions_24h,omitempty"`
+	PriceChangePercentage5m  *float64 `json:"price_change_percentage_5m,omitempty"`
+	PriceChangePercentage1h  *float64 `json:"price_change_percentage_1h,omitempty"`
+	PriceChangePercentage24h *float64 `json:"price_change_percentage_24h,omitempty"`
 }
 
-// PoolsResponse represents the response for the pools endpoint.
+// PoolsResponse represents the response for the pools endpoints.
+//
+// The DEX-pools and token-pools endpoints return rows under "pools" with
+// page-based PageInfo. The /pools/search endpoint (used by ListByNetwork)
+// returns rows under "results" with cursor-based HasNextPage/NextCursor;
+// ListByNetwork copies those rows into Pools so callers keep reading .Pools.
 type PoolsResponse struct {
-	Pools    []Pool   `json:"pools"`
-	PageInfo PageInfo `json:"page_info"`
+	Pools       []Pool   `json:"pools"`
+	Results     []Pool   `json:"results,omitempty"`
+	PageInfo    PageInfo `json:"page_info"`
+	HasNextPage bool     `json:"has_next_page,omitempty"`
+	NextCursor  *string  `json:"next_cursor,omitempty"`
 }
 
 // ListOptions contains common options for listing pools.
+//
+// Page is honored only by the legacy/DEX-pool endpoints. The cursor-paginated
+// /pools/search endpoint ignores Page; use Cursor to fetch the next page.
 type ListOptions struct {
 	Page    int
 	Limit   int
 	Sort    string
 	OrderBy string
+	Cursor  string
 }
 
 // validateNetworkID validates that a network ID is not empty
@@ -150,24 +167,44 @@ func (s *PoolsService) List(ctx context.Context, opts *ListOptions) (*PoolsRespo
 }
 
 // ListByNetwork returns a list of top pools on a specific network.
-// Implements the getNetworkPools operation from the OpenAPI spec.
 //
-// This is the recommended method to retrieve pools since API v1.3.0.
-// The global List() method has been deprecated.
+// Since the DexPaprika API removed /networks/{network}/pools (HTTP 410), this
+// method targets the unified /networks/{network}/pools/search endpoint. That
+// endpoint is cursor-paginated and rejects the legacy sort values, so the sort
+// field is normalized and the Page option is not sent upstream. Pass
+// ListOptions.Cursor (taken from a previous response's NextCursor) to page.
 func (s *PoolsService) ListByNetwork(ctx context.Context, networkID string, opts *ListOptions) (*PoolsResponse, error) {
 	if err := validateNetworkID(networkID); err != nil {
 		return nil, err
 	}
 
-	path, err := addOptions(fmt.Sprintf("/networks/%s/pools", networkID), opts)
+	req, err := s.client.NewRequest(http.MethodGet, fmt.Sprintf("/networks/%s/pools/search", networkID), nil)
 	if err != nil {
 		return nil, err
 	}
 
-	req, err := s.client.NewRequest(http.MethodGet, path, nil)
-	if err != nil {
-		return nil, err
+	q := req.URL.Query()
+	orderBy := ""
+	if opts != nil {
+		orderBy = opts.OrderBy
 	}
+	q.Add("order_by", mapPoolSortField(orderBy))
+	if opts != nil {
+		if opts.Limit > 0 {
+			limit := opts.Limit
+			if limit > 100 {
+				limit = 100
+			}
+			q.Add("limit", fmt.Sprintf("%d", limit))
+		}
+		if opts.Sort != "" {
+			q.Add("sort", opts.Sort)
+		}
+		if opts.Cursor != "" {
+			q.Add("cursor", opts.Cursor)
+		}
+	}
+	req.URL.RawQuery = q.Encode()
 
 	var response PoolsResponse
 	r, err := s.client.Do(ctx, req, &response)
@@ -175,6 +212,11 @@ func (s *PoolsService) ListByNetwork(ctx context.Context, networkID string, opts
 		return nil, err
 	}
 	defer r.Body.Close()
+
+	// /pools/search returns rows under "results"; expose them via .Pools.
+	if len(response.Pools) == 0 {
+		response.Pools = response.Results
+	}
 
 	return &response, nil
 }
@@ -434,11 +476,15 @@ func (s *PoolsService) GetTransactions(ctx context.Context, networkID, poolAddre
 }
 
 // PoolFilterOptions contains options for filtering pools on a network.
+//
+// Page is accepted for backward compatibility but is not sent to the
+// cursor-paginated /pools/search endpoint; use Cursor to page instead.
 type PoolFilterOptions struct {
 	Page          int
 	Limit         int
 	SortBy        string
 	SortDir       string
+	Cursor        string
 	Volume24hMin  *float64
 	Volume24hMax  *float64
 	Volume7dMin   *float64
@@ -450,30 +496,36 @@ type PoolFilterOptions struct {
 	CreatedBefore string
 }
 
-// PoolFilterResponse represents the response from the pool filter endpoint.
+// PoolFilterResponse represents the response from the /pools/search endpoint.
 type PoolFilterResponse struct {
-	Results  []Pool   `json:"results"`
-	PageInfo PageInfo `json:"page_info"`
+	Results     []Pool  `json:"results"`
+	HasNextPage bool    `json:"has_next_page"`
+	NextCursor  *string `json:"next_cursor,omitempty"`
 }
 
 // Filter returns pools on a network filtered by volume, liquidity, transactions, and creation date.
+//
+// Since /networks/{network}/pools/filter was removed (HTTP 410), this targets
+// the unified /networks/{network}/pools/search endpoint: filters use canonical
+// query parameter names, sorting uses order_by (normalized) plus sort
+// (direction), and pagination is cursor-based (Page is ignored, use Cursor).
 func (s *PoolsService) Filter(ctx context.Context, networkID string, opts *PoolFilterOptions) (*PoolFilterResponse, error) {
 	if err := validateNetworkID(networkID); err != nil {
 		return nil, err
 	}
 
-	path := fmt.Sprintf("/networks/%s/pools/filter", networkID)
-
-	req, err := s.client.NewRequest(http.MethodGet, path, nil)
+	req, err := s.client.NewRequest(http.MethodGet, fmt.Sprintf("/networks/%s/pools/search", networkID), nil)
 	if err != nil {
 		return nil, err
 	}
 
 	q := req.URL.Query()
+	sortBy := ""
 	if opts != nil {
-		if opts.Page > 0 {
-			q.Add("page", fmt.Sprintf("%d", opts.Page))
-		}
+		sortBy = opts.SortBy
+	}
+	q.Add("order_by", mapPoolSortField(sortBy))
+	if opts != nil {
 		if opts.Limit > 0 {
 			limit := opts.Limit
 			if limit > 100 {
@@ -481,23 +533,23 @@ func (s *PoolsService) Filter(ctx context.Context, networkID string, opts *PoolF
 			}
 			q.Add("limit", fmt.Sprintf("%d", limit))
 		}
-		if opts.SortBy != "" {
-			q.Add("sort_by", opts.SortBy)
-		}
 		if opts.SortDir != "" {
-			q.Add("sort_dir", opts.SortDir)
+			q.Add("sort", opts.SortDir)
+		}
+		if opts.Cursor != "" {
+			q.Add("cursor", opts.Cursor)
 		}
 		if opts.Volume24hMin != nil {
-			q.Add("volume_24h_min", fmt.Sprintf("%f", *opts.Volume24hMin))
+			q.Add("volume_usd_24h_min", fmt.Sprintf("%f", *opts.Volume24hMin))
 		}
 		if opts.Volume24hMax != nil {
-			q.Add("volume_24h_max", fmt.Sprintf("%f", *opts.Volume24hMax))
+			q.Add("volume_usd_24h_max", fmt.Sprintf("%f", *opts.Volume24hMax))
 		}
 		if opts.Volume7dMin != nil {
-			q.Add("volume_7d_min", fmt.Sprintf("%f", *opts.Volume7dMin))
+			q.Add("volume_usd_7d_min", fmt.Sprintf("%f", *opts.Volume7dMin))
 		}
 		if opts.Volume7dMax != nil {
-			q.Add("volume_7d_max", fmt.Sprintf("%f", *opts.Volume7dMax))
+			q.Add("volume_usd_7d_max", fmt.Sprintf("%f", *opts.Volume7dMax))
 		}
 		if opts.LiquidityMin != nil {
 			q.Add("liquidity_usd_min", fmt.Sprintf("%f", *opts.LiquidityMin))

--- a/dexpaprika/search_mapping.go
+++ b/dexpaprika/search_mapping.go
@@ -1,0 +1,81 @@
+package dexpaprika
+
+// This file holds the small, pure helpers that translate the SDK's historical
+// sort-field names into the canonical field names accepted by the unified
+// /pools/search and /tokens/search endpoints.
+//
+// The search endpoints reject legacy values with HTTP 400, so every sort field
+// the caller supplies has to be normalized before it goes on the wire. An empty
+// or unrecognized value falls back to the API default, "volume_usd_24h".
+
+// defaultSearchSortField is returned for empty or unknown sort fields.
+const defaultSearchSortField = "volume_usd_24h"
+
+// mapPoolSortField maps a pools sort field to the canonical value accepted by
+// /networks/{network}/pools/search. Canonical values pass through unchanged.
+func mapPoolSortField(field string) string {
+	switch field {
+	// Legacy -> canonical
+	case "volume_usd", "volume_24h":
+		return "volume_usd_24h"
+	case "transactions":
+		return "txns_24h"
+	case "last_price_change_usd_24h":
+		return "price_change_percentage_24h"
+	case "volume_7d":
+		return "volume_usd_7d"
+	case "volume_30d":
+		return "volume_usd_30d"
+	case "liquidity":
+		return "liquidity_usd"
+	// Canonical pass-through
+	case "volume_usd_24h",
+		"volume_usd_7d",
+		"volume_usd_30d",
+		"liquidity_usd",
+		"txns_24h",
+		"created_at",
+		"price_usd",
+		"price_change_percentage_24h":
+		return field
+	default:
+		return defaultSearchSortField
+	}
+}
+
+// mapTokenSortField maps a tokens sort field to the canonical value accepted by
+// /networks/{network}/tokens/search. Canonical values pass through unchanged.
+// Note: tokens/search rejects ordering by price, so "price_usd" is remapped to
+// the default rather than passed through.
+func mapTokenSortField(field string) string {
+	switch field {
+	// Legacy -> canonical
+	case "volume_24h":
+		return "volume_usd_24h"
+	case "txns":
+		return "txns_24h"
+	case "price_change":
+		return "price_change_percentage_24h"
+	case "fdv":
+		return "fdv_usd"
+	case "volume_7d":
+		return "volume_usd_7d"
+	case "volume_30d":
+		return "volume_usd_30d"
+	case "price_usd":
+		// tokens/search returns 400 when ordering by price.
+		return "volume_usd_24h"
+	// Canonical pass-through
+	case "volume_usd_24h",
+		"volume_usd_7d",
+		"volume_usd_30d",
+		"liquidity_usd",
+		"txns_24h",
+		"fdv_usd",
+		"created_at",
+		"price_change_percentage_24h":
+		return field
+	default:
+		return defaultSearchSortField
+	}
+}

--- a/dexpaprika/tokens.go
+++ b/dexpaprika/tokens.go
@@ -139,64 +139,55 @@ func (s *TokensService) GetPools(ctx context.Context, networkID, tokenAddress st
 	return &response, nil
 }
 
-// TopTokenTimeMetrics represents time interval metrics for top tokens.
-type TopTokenTimeMetrics struct {
-	VolumeUSD          float64  `json:"volume_usd"`
-	Txns               int      `json:"txns"`
-	LastPriceUSDChange *float64 `json:"last_price_usd_change,omitempty"`
-	Buys               *int     `json:"buys,omitempty"`
-	Sells              *int     `json:"sells,omitempty"`
-}
+// TopToken is an alias for FilteredToken, kept for backward compatibility.
+// Since the API removed /networks/{network}/tokens/top, GetTop now returns the
+// flat /tokens/search row shape (FilteredToken). The legacy name/symbol and
+// nested timeframe metrics are no longer returned by the API.
+type TopToken = FilteredToken
 
-// TopToken represents a token from the top tokens endpoint.
-type TopToken struct {
-	Address      string               `json:"address"`
-	Name         string               `json:"name"`
-	Symbol       string               `json:"symbol"`
-	Chain        string               `json:"chain"`
-	Decimals     int                  `json:"decimals"`
-	HasImage     *bool                `json:"has_image,omitempty"`
-	PriceUSD     *float64             `json:"price_usd,omitempty"`
-	FDV          *float64             `json:"fdv,omitempty"`
-	LiquidityUSD *float64             `json:"liquidity_usd,omitempty"`
-	Pools        *int                 `json:"pools,omitempty"`
-	Day          *TopTokenTimeMetrics `json:"24h,omitempty"`
-	Hour1        *TopTokenTimeMetrics `json:"1h,omitempty"`
-	Minute5      *TopTokenTimeMetrics `json:"5m,omitempty"`
-}
-
-// TopTokensResponse represents the response from the top tokens endpoint.
+// TopTokensResponse represents the response from the /tokens/search endpoint.
 type TopTokensResponse struct {
-	Tokens   []TopToken `json:"tokens"`
-	PageInfo PageInfo   `json:"page_info"`
+	Tokens      []TopToken `json:"results"`
+	HasNextPage bool       `json:"has_next_page"`
+	NextCursor  *string    `json:"next_cursor,omitempty"`
 }
 
-// TopTokensOptions contains options for the top tokens endpoint.
+// TopTokensOptions contains options for ranking tokens.
+//
+// Page is accepted for backward compatibility but is not sent to the
+// cursor-paginated /tokens/search endpoint; use Cursor to page instead.
 type TopTokensOptions struct {
 	Page    int
 	Limit   int
 	OrderBy string
 	Sort    string
+	Cursor  string
 }
 
-// GetTop returns top tokens on a network ranked by volume, price, liquidity, or other metrics.
+// GetTop returns top tokens on a network ranked by volume, liquidity, FDV, or
+// other metrics.
+//
+// Since /networks/{network}/tokens/top was removed (HTTP 410), this targets the
+// unified /networks/{network}/tokens/search endpoint: the sort field is
+// normalized to a canonical value and pagination is cursor-based (Page is
+// ignored, use Cursor).
 func (s *TokensService) GetTop(ctx context.Context, networkID string, opts *TopTokensOptions) (*TopTokensResponse, error) {
 	if err := validateNetworkID(networkID); err != nil {
 		return nil, err
 	}
 
-	path := fmt.Sprintf("/networks/%s/tokens/top", networkID)
-
-	req, err := s.client.NewRequest(http.MethodGet, path, nil)
+	req, err := s.client.NewRequest(http.MethodGet, fmt.Sprintf("/networks/%s/tokens/search", networkID), nil)
 	if err != nil {
 		return nil, err
 	}
 
 	q := req.URL.Query()
+	orderBy := ""
 	if opts != nil {
-		if opts.Page > 0 {
-			q.Add("page", fmt.Sprintf("%d", opts.Page))
-		}
+		orderBy = opts.OrderBy
+	}
+	q.Add("order_by", mapTokenSortField(orderBy))
+	if opts != nil {
 		if opts.Limit > 0 {
 			limit := opts.Limit
 			if limit > 100 {
@@ -204,11 +195,11 @@ func (s *TokensService) GetTop(ctx context.Context, networkID string, opts *TopT
 			}
 			q.Add("limit", fmt.Sprintf("%d", limit))
 		}
-		if opts.OrderBy != "" {
-			q.Add("order_by", opts.OrderBy)
-		}
 		if opts.Sort != "" {
 			q.Add("sort", opts.Sort)
+		}
+		if opts.Cursor != "" {
+			q.Add("cursor", opts.Cursor)
 		}
 	}
 	req.URL.RawQuery = q.Encode()
@@ -223,34 +214,38 @@ func (s *TokensService) GetTop(ctx context.Context, networkID string, opts *TopT
 	return &response, nil
 }
 
-// FilteredToken represents a token from the token filter endpoint.
+// FilteredToken represents a token row from the /tokens/search endpoint.
 type FilteredToken struct {
-	Chain        string   `json:"chain"`
-	Address      string   `json:"address"`
-	PriceUSD     *float64 `json:"price_usd,omitempty"`
-	VolumeUSD24h *float64 `json:"volume_usd_24h,omitempty"`
-	VolumeUSD7d  *float64 `json:"volume_usd_7d,omitempty"`
-	VolumeUSD30d *float64 `json:"volume_usd_30d,omitempty"`
-	LiquidityUSD *float64 `json:"liquidity_usd,omitempty"`
-	FDVUSD       *float64 `json:"fdv_usd,omitempty"`
-	Txns24h      *int     `json:"txns_24h,omitempty"`
-	CreatedAt    string   `json:"created_at,omitempty"`
+	Chain                    string   `json:"chain"`
+	Address                  string   `json:"address"`
+	PriceUSD                 *float64 `json:"price_usd,omitempty"`
+	VolumeUSD24h             *float64 `json:"volume_usd_24h,omitempty"`
+	VolumeUSD7d              *float64 `json:"volume_usd_7d,omitempty"`
+	VolumeUSD30d             *float64 `json:"volume_usd_30d,omitempty"`
+	LiquidityUSD             *float64 `json:"liquidity_usd,omitempty"`
+	FDVUSD                   *float64 `json:"fdv_usd,omitempty"`
+	Txns24h                  *int     `json:"txns_24h,omitempty"`
+	PriceChangePercentage24h *float64 `json:"price_change_percentage_24h,omitempty"`
+	CreatedAt                string   `json:"created_at,omitempty"`
 }
 
-// TokenFilterResponse represents the response from the token filter endpoint.
-// The endpoint returns its rows under a "data" key (not "results"), so Results
-// is tagged accordingly to stay backward-compatible for callers using .Results.
+// TokenFilterResponse represents the response from the /tokens/search endpoint.
 type TokenFilterResponse struct {
-	Results  []FilteredToken `json:"data"`
-	PageInfo PageInfo        `json:"page_info"`
+	Results     []FilteredToken `json:"results"`
+	HasNextPage bool            `json:"has_next_page"`
+	NextCursor  *string         `json:"next_cursor,omitempty"`
 }
 
 // TokenFilterOptions contains options for filtering tokens on a network.
+//
+// Page is accepted for backward compatibility but is not sent to the
+// cursor-paginated /tokens/search endpoint; use Cursor to page instead.
 type TokenFilterOptions struct {
 	Page          int
 	Limit         int
 	SortBy        string
 	SortDir       string
+	Cursor        string
 	Volume24hMin  *float64
 	Volume24hMax  *float64
 	LiquidityMin  *float64
@@ -262,23 +257,28 @@ type TokenFilterOptions struct {
 }
 
 // Filter returns tokens on a network filtered by volume, liquidity, FDV, transactions, and creation date.
+//
+// Since /networks/{network}/tokens/filter was removed (HTTP 410), this targets
+// the unified /networks/{network}/tokens/search endpoint: filters use canonical
+// query parameter names, sorting uses order_by (normalized) plus sort
+// (direction), and pagination is cursor-based (Page is ignored, use Cursor).
 func (s *TokensService) Filter(ctx context.Context, networkID string, opts *TokenFilterOptions) (*TokenFilterResponse, error) {
 	if err := validateNetworkID(networkID); err != nil {
 		return nil, err
 	}
 
-	path := fmt.Sprintf("/networks/%s/tokens/filter", networkID)
-
-	req, err := s.client.NewRequest(http.MethodGet, path, nil)
+	req, err := s.client.NewRequest(http.MethodGet, fmt.Sprintf("/networks/%s/tokens/search", networkID), nil)
 	if err != nil {
 		return nil, err
 	}
 
 	q := req.URL.Query()
+	sortBy := ""
 	if opts != nil {
-		if opts.Page > 0 {
-			q.Add("page", fmt.Sprintf("%d", opts.Page))
-		}
+		sortBy = opts.SortBy
+	}
+	q.Add("order_by", mapTokenSortField(sortBy))
+	if opts != nil {
 		if opts.Limit > 0 {
 			limit := opts.Limit
 			if limit > 100 {
@@ -286,17 +286,17 @@ func (s *TokensService) Filter(ctx context.Context, networkID string, opts *Toke
 			}
 			q.Add("limit", fmt.Sprintf("%d", limit))
 		}
-		if opts.SortBy != "" {
-			q.Add("sort_by", opts.SortBy)
-		}
 		if opts.SortDir != "" {
-			q.Add("sort_dir", opts.SortDir)
+			q.Add("sort", opts.SortDir)
+		}
+		if opts.Cursor != "" {
+			q.Add("cursor", opts.Cursor)
 		}
 		if opts.Volume24hMin != nil {
-			q.Add("volume_24h_min", fmt.Sprintf("%f", *opts.Volume24hMin))
+			q.Add("volume_usd_24h_min", fmt.Sprintf("%f", *opts.Volume24hMin))
 		}
 		if opts.Volume24hMax != nil {
-			q.Add("volume_24h_max", fmt.Sprintf("%f", *opts.Volume24hMax))
+			q.Add("volume_usd_24h_max", fmt.Sprintf("%f", *opts.Volume24hMax))
 		}
 		if opts.LiquidityMin != nil {
 			q.Add("liquidity_usd_min", fmt.Sprintf("%f", *opts.LiquidityMin))

--- a/examples/production_usage.go
+++ b/examples/production_usage.go
@@ -103,13 +103,18 @@ func main() {
 	} else {
 		fmt.Printf("   Found %d pools on Ethereum\n", len(pools.Pools))
 
-		// Display first pool
+		// Display first pool. The /pools/search endpoint returns 24h volume in
+		// VolumeUSD24h (a pointer), so guard against a nil value.
 		if len(pools.Pools) > 0 {
 			pool := pools.Pools[0]
-			fmt.Printf("   Top pool: %s on %s (Volume: $%.2f)\n",
+			vol24h := 0.0
+			if pool.VolumeUSD24h != nil {
+				vol24h = *pool.VolumeUSD24h
+			}
+			fmt.Printf("   Top pool: %s on %s (24h Volume: $%.2f)\n",
 				pool.DexName,
 				pool.Chain,
-				pool.VolumeUSD)
+				vol24h)
 		}
 	}
 


### PR DESCRIPTION
DexPaprika removed four REST endpoints (HTTP 410): `/networks/{network}/pools`, `/networks/{network}/pools/filter`, `/networks/{network}/tokens/top`, `/networks/{network}/tokens/filter`. The network-pools, pool-filter, top-tokens, and token-filter methods were erroring.

## Fix

Repoint all four to the unified search endpoints (method names + signatures unchanged for back-compat):

- network pools, pool filter -> `/networks/{network}/pools/search`
- top tokens, token filter -> `/networks/{network}/tokens/search`

A shared helper normalizes legacy sort-field values (`volume_usd` -> `volume_usd_24h`, `transactions` -> `txns_24h`, `last_price_change_usd_24h` -> `price_change_percentage_24h`, ...) and legacy filter param names (`volume_24h_min` -> `volume_usd_24h_min`, ...). The search endpoints **400** on the old names, so this mapping is required; the filter methods now send `order_by` + `sort`. Token sort by price falls back to volume (the token search rejects price ordering).

Responses are cursor-paginated: rows under `results` with `has_next_page` + `next_cursor` (no `page_info`); models use the new field names (`id` not `address` for pools, `transactions_24h`, `price_change_percentage_24h`, `fdv_usd`, ...). The new flat token shape has no name/symbol/buys/sells, so token models reflect what the API returns. Legacy params are still accepted; `page` is kept in signatures but no longer sent (an optional `cursor` is added).

## Verified

Live against api.dexpaprika.com: build and test suite pass; all four methods return real rows in both default and JSON usage; legacy sort values map instead of 400; zero em/en dashes.

## Release

After merge: tag the release (e.g. `git tag v1.5.0 && git push origin v1.5.0`); the Go proxy picks it up. The pre-existing deprecated global `/pools` list method is intentionally left to surface its deprecation (out of scope).