### PR TITLE
Surface 410 replacement on APIError + fix dropped message

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,10 @@
 # Changelog
 
+## [1.5.1] - 2026-07-01
+
+### Changed
+- **Deprecation errors surface the replacement**: `APIError` now has a `Replacement` field, populated from the API error body's `replacement`, and the error message includes `Use <replacement> instead.`. Also fixes a bug where the API's `message` was dropped when the body had no `error` key. `ErrGone` still matches via `errors.Is`. Generic across any error status carrying a `replacement`.
+
 ## [1.5.0] - 2026-06-30
 
 ### Breaking Changes

--- a/dexpaprika/client.go
+++ b/dexpaprika/client.go
@@ -196,8 +196,14 @@ var (
 
 // APIError represents a structured API error
 type APIError struct {
-	StatusCode  int
-	Message     string
+	StatusCode int
+	Message    string
+	// Replacement is the endpoint the API suggests using instead, parsed from
+	// the "replacement" field of the error body when present. It is populated
+	// for any error status (not only 410), so self-documenting deprecations are
+	// discoverable by callers via err.Replacement. Empty when the API did not
+	// advertise a replacement.
+	Replacement string
 	RawResponse []byte
 	Err         error
 }
@@ -350,18 +356,30 @@ func (c *Client) Do(ctx context.Context, req *http.Request, v interface{}) (*htt
 // createAPIError creates an appropriate APIError based on the HTTP status code
 func createAPIError(resp *http.Response, body []byte) *APIError {
 	var errMsg string
+	var replacement string
 	var err error
 
-	// Try to extract an error message from body
+	// Try to extract an error message from the body. This parse is defensive:
+	// the body may not be JSON, or may omit any of these fields. In that case
+	// the fields stay empty and we fall back to the status-based defaults below.
 	var errorResp struct {
-		Error   string `json:"error"`
-		Message string `json:"message"`
+		Error       string `json:"error"`
+		Message     string `json:"message"`
+		Replacement string `json:"replacement"`
 	}
-	if err := json.Unmarshal(body, &errorResp); err == nil && errorResp.Error != "" {
-		errMsg = errorResp.Error
-		if errorResp.Message != "" {
-			errMsg = errMsg + ": " + errorResp.Message
+	if jsonErr := json.Unmarshal(body, &errorResp); jsonErr == nil {
+		switch {
+		case errorResp.Error != "" && errorResp.Message != "":
+			errMsg = errorResp.Error + ": " + errorResp.Message
+		case errorResp.Error != "":
+			errMsg = errorResp.Error
+		case errorResp.Message != "":
+			// Some responses (notably the 410 deprecation body) carry only
+			// "message" with no "error" key. Use it so the API's own text is
+			// not silently dropped.
+			errMsg = errorResp.Message
 		}
+		replacement = errorResp.Replacement
 	}
 
 	// Map status codes to appropriate errors
@@ -376,7 +394,8 @@ func createAPIError(resp *http.Response, body []byte) *APIError {
 		err = ErrNotFound
 	case 410:
 		err = ErrGone
-		// Provide helpful migration message for deprecated /pools endpoint
+		// Provide a helpful migration message for deprecated endpoints only
+		// when the API did not supply one of its own.
 		if errMsg == "" {
 			errMsg = "This endpoint has been deprecated. Please use network-specific endpoints instead.\n\nExamples:\n- client.Pools.ListByNetwork('ethereum', opts)\n- client.Pools.ListByNetwork('solana', opts)\n- client.Pools.ListByNetwork('fantom', opts)\n\nFor more information, visit: https://docs.dexpaprika.com/changelog/changelog"
 		}
@@ -394,9 +413,22 @@ func createAPIError(resp *http.Response, body []byte) *APIError {
 		}
 	}
 
+	// If the API advertised a replacement endpoint, surface it in the message
+	// for ANY error status. This keys on the presence of the "replacement"
+	// field rather than a specific status or endpoint, so future deprecations
+	// self-document without further SDK changes.
+	if replacement != "" {
+		if errMsg != "" {
+			errMsg = errMsg + " Use " + replacement + " instead."
+		} else {
+			errMsg = "Use " + replacement + " instead."
+		}
+	}
+
 	return &APIError{
 		StatusCode:  resp.StatusCode,
 		Message:     errMsg,
+		Replacement: replacement,
 		RawResponse: body,
 		Err:         err,
 	}

--- a/dexpaprika/client_test.go
+++ b/dexpaprika/client_test.go
@@ -185,6 +185,65 @@ func TestAPIError_Error(t *testing.T) {
 	}
 }
 
+// TestClient_Do_GoneWithReplacement verifies that a 410 body carrying only
+// "message" and "replacement" (no "error" key) surfaces BOTH the API message
+// and the replacement endpoint, and exposes err.Replacement to callers.
+func TestClient_Do_GoneWithReplacement(t *testing.T) {
+	const replacement = "/networks/:network/pools/search"
+	body := `{"code":410,"message":"endpoint removed","replacement":"` + replacement + `"}`
+
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		w.WriteHeader(http.StatusGone)
+		fmt.Fprintln(w, body)
+	}))
+	defer server.Close()
+
+	client := NewClient(
+		WithBaseURL(server.URL),
+		WithRetryConfig(0, 1*time.Millisecond, 1*time.Millisecond),
+	)
+
+	req, err := client.NewRequest(http.MethodGet, "/test", nil)
+	if err != nil {
+		t.Fatalf("NewRequest returned error: %v", err)
+	}
+
+	var result interface{}
+	resp, err := client.Do(context.Background(), req, &result)
+	if resp != nil && resp.Body != nil {
+		defer resp.Body.Close()
+	}
+	if err == nil {
+		t.Fatal("Do() returned nil error, want error")
+	}
+
+	if !errors.Is(err, ErrGone) {
+		t.Errorf("Do() error = %v, want it to wrap ErrGone", err)
+	}
+
+	var apiErr *APIError
+	if !errors.As(err, &apiErr) {
+		t.Fatalf("Do() returned error of type %T, want *APIError", err)
+	}
+
+	if apiErr.StatusCode != http.StatusGone {
+		t.Errorf("APIError.StatusCode = %d, want %d", apiErr.StatusCode, http.StatusGone)
+	}
+	if apiErr.Replacement != replacement {
+		t.Errorf("APIError.Replacement = %q, want %q", apiErr.Replacement, replacement)
+	}
+	if !strings.Contains(apiErr.Message, "endpoint removed") {
+		t.Errorf("APIError.Message = %q, want it to contain the API message %q", apiErr.Message, "endpoint removed")
+	}
+	if !strings.Contains(apiErr.Message, replacement) {
+		t.Errorf("APIError.Message = %q, want it to contain the replacement %q", apiErr.Message, replacement)
+	}
+	if !strings.Contains(apiErr.Error(), "Use "+replacement+" instead.") {
+		t.Errorf("APIError.Error() = %q, want it to contain the replacement hint", apiErr.Error())
+	}
+}
+
 // TestClient_NewRequestWithBody tests creating a request with a body
 func TestClient_NewRequestWithBody(t *testing.T) {
 	client := NewClient()


### PR DESCRIPTION
`APIError` gains a `Replacement` field (from the body's `replacement`) and the message now includes `Use <replacement> instead.`. Also fixes a bug where the API's `message` was dropped when the body had no `error` key (the 410 body has `message`+`replacement`, no `error`). `ErrGone` still matches via `errors.Is`. go build/vet pass; unit tests pass (live suite hits 429s on untouched endpoints only). Release after merge: tag `v1.5.1`.