### PR TITLE
fix: migrate Tokens.GetPools to /pools/search (token-pools endpoint removed)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,15 @@
 # Changelog
 
+## [1.6.0] - 2026-07-15
+
+### Breaking Changes
+- **API CHANGE**: DexPaprika removed `GET /networks/{network}/tokens/{address}/pools` (now HTTP 410). `Tokens.GetPools()` now targets `GET /networks/{network}/pools/search` with its new `token_address` parameter. The method signature is unchanged.
+- The token filter is network-scoped only: the cross-network `/pools/search` endpoint accepts `token_address` but silently ignores it, so `GetPools` still requires a network.
+- Pagination is cursor-based: `Page` is still accepted for source compatibility but is no longer sent; use `ListOptions.Cursor` (read from a response's `NextCursor`) to page. Sort fields are normalized to the canonical 24h names (legacy values are rejected by the endpoint with HTTP 400).
+- `TokenPoolsOptions.AdditionalTokenAddress` (pair queries) and `TokenPoolsOptions.Reorder` (pair-perspective flip) are deprecated and no longer sent: `/pools/search` has no equivalent for either, and repeating `token_address` is last-wins on the API side, not a pair filter. Filter pools client-side by their `Tokens` field to match a pair.
+- An unknown token address now returns HTTP 200 with an empty result set instead of an error.
+- `PoolsPaginator.ForToken` pages token pools by cursor; its `secondToken` argument is deprecated and ignored.
+
 ## [1.5.1] - 2026-07-01
 
 ### Changed

--- a/README.md
+++ b/README.md
@@ -327,26 +327,24 @@ transactions, err := client.Pools.GetTransactions(ctx, "ethereum", "0xpool_addre
 // Get details about a specific token
 tokenDetails, err := client.Tokens.GetDetails(ctx, "ethereum", "0xtoken_address")
 
-// Get pools that contain a specific token
+// Get pools that contain a specific token.
+// This targets /networks/{network}/pools/search with token_address, so the
+// filter is network-scoped and results are cursor-paginated: pass
+// Cursor (from a response's NextCursor) to fetch the next page.
 tokenPools, err := client.Tokens.GetPools(ctx, "ethereum", "0xtoken_address", &dexpaprika.TokenPoolsOptions{
     ListOptions: &dexpaprika.ListOptions{
         Limit:   10,
-        OrderBy: "volume_usd",
+        OrderBy: "volume_usd_24h",
         Sort:    "desc",
     },
-})
-
-// Get pools that contain a pair of tokens with reordering
-pairPools, err := client.Tokens.GetPools(ctx, "ethereum", "0xtoken1_address", &dexpaprika.TokenPoolsOptions{
-    ListOptions: &dexpaprika.ListOptions{
-        Limit:   10,
-        OrderBy: "volume_usd",
-        Sort:    "desc",
-    },
-    AdditionalTokenAddress: "0xtoken2_address",
-    Reorder: true,
 })
 ```
+
+Note: the removed token-pools endpoint supported pair queries (a second token
+address) and metric reordering (`reorder`). `/pools/search` has no equivalent
+for either, so `AdditionalTokenAddress` and `Reorder` are deprecated and no
+longer sent. To restrict results to a pair, filter the returned pools
+client-side by their `Tokens` field.
 
 ### Pool Filtering
 

--- a/dexpaprika/cache.go
+++ b/dexpaprika/cache.go
@@ -258,25 +258,24 @@ func (c *CachedClient) GetTokenDetails(ctx context.Context, networkID, tokenAddr
 	return details, nil
 }
 
-// GetTokenPools retrieves token pools with caching
+// GetTokenPools retrieves token pools with caching.
+//
+// The underlying endpoint is the cursor-paginated /pools/search, so the cache
+// key is built from the options that are actually sent on the wire (limit,
+// sort, order_by, cursor). The deprecated AdditionalTokenAddress and Reorder
+// options are ignored.
 func (c *CachedClient) GetTokenPools(ctx context.Context, networkID, tokenAddress string, opts *TokenPoolsOptions) (*PoolsResponse, error) {
-	var optsPage, optsLimit int
-	var optsSort, optsOrderBy string
-	var additionalToken string
-	var reorder bool
+	var optsLimit int
+	var optsSort, optsOrderBy, optsCursor string
 
-	if opts != nil {
-		if opts.ListOptions != nil {
-			optsPage = opts.Page
-			optsLimit = opts.Limit
-			optsSort = opts.Sort
-			optsOrderBy = opts.OrderBy
-		}
-		additionalToken = opts.AdditionalTokenAddress
-		reorder = opts.Reorder
+	if opts != nil && opts.ListOptions != nil {
+		optsLimit = opts.Limit
+		optsSort = opts.Sort
+		optsOrderBy = opts.OrderBy
+		optsCursor = opts.Cursor
 	}
 
-	cacheKey := fmt.Sprintf("token_pools:%s:%s:%d:%d:%s:%s:%s:%t", networkID, tokenAddress, optsPage, optsLimit, optsSort, optsOrderBy, additionalToken, reorder)
+	cacheKey := fmt.Sprintf("token_pools:%s:%s:%d:%s:%s:%s", networkID, tokenAddress, optsLimit, optsSort, optsOrderBy, optsCursor)
 
 	// Try to get from cache first
 	if cachedValue, found := c.cache.Get(cacheKey); found {

--- a/dexpaprika/comprehensive_test.go
+++ b/dexpaprika/comprehensive_test.go
@@ -126,12 +126,18 @@ func TestAllEndpoints(t *testing.T) {
 		case "/networks/ethereum/tokens/0xa0b86991c6218b36c1d19d4a2e9eb0ce3606eb48":
 			writeTestJSON(w, createMockToken("0xa0b86991c6218b36c1d19d4a2e9eb0ce3606eb48", "ethereum"))
 
-		case "/networks/ethereum/tokens/0xa0b86991c6218b36c1d19d4a2e9eb0ce3606eb48/pools":
+		case "/networks/ethereum/pools/search":
+			// Token pools now go through /pools/search with token_address.
+			if r.URL.Query().Get("token_address") != "0xa0b86991c6218b36c1d19d4a2e9eb0ce3606eb48" {
+				w.WriteHeader(http.StatusBadRequest)
+				return
+			}
 			writeTestJSON(w, map[string]interface{}{
-				"pools": []map[string]interface{}{
+				"results": []map[string]interface{}{
 					createMockPool("0xb4e16d0168e52d35cacd2c6185b44281ec28c9dc", "ethereum"),
 				},
-				"page_info": createPageInfo(20, 0, 1, 100),
+				"has_next_page": false,
+				"next_cursor":   "",
 			})
 
 		// Search endpoint
@@ -439,23 +445,13 @@ func testGetTokenDetails(t *testing.T, ctx context.Context, client *Client) {
 
 func testGetTokenPools(t *testing.T, ctx context.Context, client *Client) {
 	tokenAddress := "0xa0b86991c6218b36c1d19d4a2e9eb0ce3606eb48" // #nosec G101 - This is a public token address, not a credential
-	req, err := client.NewRequest(http.MethodGet, "/networks/ethereum/tokens/"+tokenAddress+"/pools", nil)
-	if err != nil {
-		t.Fatalf("Failed to create request: %v", err)
-	}
-
-	var resp map[string]interface{}
-	httpResp, err := client.Do(ctx, req, &resp)
+	resp, err := client.Tokens.GetPools(ctx, "ethereum", tokenAddress, nil)
 	if err != nil {
 		t.Fatalf("Failed to get token pools: %v", err)
 	}
-	if httpResp != nil && httpResp.Body != nil {
-		defer httpResp.Body.Close()
-	}
 
-	pools, ok := resp["pools"].([]interface{})
-	if !ok || len(pools) != 1 {
-		t.Errorf("Expected 1 pool, got %v", pools)
+	if len(resp.Pools) != 1 {
+		t.Errorf("Expected 1 pool, got %v", resp.Pools)
 	}
 }
 

--- a/dexpaprika/pagination.go
+++ b/dexpaprika/pagination.go
@@ -24,11 +24,11 @@ type PoolsPaginator struct {
 	err         error
 }
 
-// isNetworkSearch reports whether this paginator fetches network pools via the
-// cursor-paginated /pools/search endpoint (as opposed to the page-based DEX-pool
-// or token-pool endpoints).
+// isNetworkSearch reports whether this paginator fetches pools via the
+// cursor-paginated /pools/search endpoint (network pools and token pools, as
+// opposed to the page-based DEX-pool endpoint).
 func (p *PoolsPaginator) isNetworkSearch() bool {
-	return p.networkID != "" && p.dexID == "" && p.tokenID == ""
+	return p.networkID != "" && p.dexID == ""
 }
 
 // NewPoolsPaginator creates a new paginator for pools
@@ -58,7 +58,11 @@ func (p *PoolsPaginator) ForDex(networkID, dexID string) *PoolsPaginator {
 	return p
 }
 
-// ForToken sets the paginator to fetch pools containing a specific token
+// ForToken sets the paginator to fetch pools containing a specific token.
+//
+// secondToken is deprecated and ignored: the /pools/search endpoint that now
+// backs token pools has no pair filter. Pass "" and filter client-side if a
+// pair is needed.
 func (p *PoolsPaginator) ForToken(networkID, tokenID string, secondToken string) *PoolsPaginator {
 	p.networkID = networkID
 	p.tokenID = tokenID
@@ -107,13 +111,10 @@ func (p *PoolsPaginator) GetNextPage(ctx context.Context) error {
 	// Determine which API endpoint to call based on the set parameters
 	switch {
 	case p.tokenID != "":
-		// Token pools (page-based) - use new TokenPoolsOptions struct
-		if p.currentResp != nil {
-			p.options.Page++
-		}
+		// Token pools (cursor-based /pools/search with token_address)
+		p.options.Cursor = p.cursor
 		tokenOpts := &TokenPoolsOptions{
-			ListOptions:            p.options,
-			AdditionalTokenAddress: p.secondToken,
+			ListOptions: p.options,
 		}
 		resp, err = p.client.Tokens.GetPools(ctx, p.networkID, p.tokenID, tokenOpts)
 	case p.dexID != "":

--- a/dexpaprika/tokens.go
+++ b/dexpaprika/tokens.go
@@ -74,16 +74,38 @@ func (s *TokensService) GetDetails(ctx context.Context, networkID, tokenAddress 
 }
 
 // TokenPoolsOptions contains options for retrieving token pools.
+//
+// Page is accepted for backward compatibility but is not sent to the
+// cursor-paginated /pools/search endpoint; use ListOptions.Cursor to page.
 type TokenPoolsOptions struct {
 	*ListOptions
-	// AdditionalTokenAddress filters pools that contain this additional token address
+	// AdditionalTokenAddress used to filter pools that also contain a second
+	// token (pair queries) on the removed token-pools endpoint.
+	//
+	// Deprecated: /pools/search has no pair filter and its token_address
+	// parameter is last-wins when repeated, so this option is no longer sent.
+	// Filter the returned pools client-side to match a pair.
 	AdditionalTokenAddress string
-	// Reorder reorders the pool so that the specified token becomes the primary token for all metrics
+	// Reorder used to flip the pool's pair perspective so the requested token
+	// became the primary token for all metrics.
+	//
+	// Deprecated: /pools/search has no equivalent, so this option is no longer
+	// sent. Metrics are returned from the pool's own perspective.
 	Reorder bool
 }
 
-// GetPools returns a list of top liquidity pools for a specific token on a network.
-// Implements the getTokenPools operation from the OpenAPI spec.
+// GetPools returns a list of top liquidity pools that contain a specific token
+// on a network.
+//
+// Since the DexPaprika API removed /networks/{network}/tokens/{address}/pools
+// (HTTP 410), this method targets the unified /networks/{network}/pools/search
+// endpoint with its token_address parameter. The filter is network-scoped
+// only: the cross-network /pools/search endpoint accepts token_address but
+// silently ignores it, so a network is always required here. The endpoint is
+// cursor-paginated and rejects legacy sort values, so the sort field is
+// normalized and the Page option is not sent upstream; pass ListOptions.Cursor
+// (taken from a previous response's NextCursor) to page. An unknown token
+// address returns an empty result set, not an error.
 func (s *TokensService) GetPools(ctx context.Context, networkID, tokenAddress string, opts *TokenPoolsOptions) (*PoolsResponse, error) {
 	if err := validateNetworkID(networkID); err != nil {
 		return nil, err
@@ -92,39 +114,31 @@ func (s *TokensService) GetPools(ctx context.Context, networkID, tokenAddress st
 		return nil, fmt.Errorf("token address is required")
 	}
 
-	path := fmt.Sprintf("/networks/%s/tokens/%s/pools", networkID, tokenAddress)
-
-	req, err := s.client.NewRequest(http.MethodGet, path, nil)
+	req, err := s.client.NewRequest(http.MethodGet, fmt.Sprintf("/networks/%s/pools/search", networkID), nil)
 	if err != nil {
 		return nil, err
 	}
 
 	q := req.URL.Query()
-	if opts != nil {
-		if opts.ListOptions != nil {
-			if opts.Page > 0 {
-				q.Add("page", fmt.Sprintf("%d", opts.Page))
+	q.Add("token_address", tokenAddress)
+	orderBy := ""
+	if opts != nil && opts.ListOptions != nil {
+		orderBy = opts.OrderBy
+	}
+	q.Add("order_by", mapPoolSortField(orderBy))
+	if opts != nil && opts.ListOptions != nil {
+		if opts.Limit > 0 {
+			limit := opts.Limit
+			if limit > 100 {
+				limit = 100
 			}
-			if opts.Limit > 0 {
-				// Validate limit constraints (max 100 as per API v1.3.0)
-				limit := opts.Limit
-				if limit > 100 {
-					limit = 100
-				}
-				q.Add("limit", fmt.Sprintf("%d", limit))
-			}
-			if opts.Sort != "" {
-				q.Add("sort", opts.Sort)
-			}
-			if opts.OrderBy != "" {
-				q.Add("order_by", opts.OrderBy)
-			}
+			q.Add("limit", fmt.Sprintf("%d", limit))
 		}
-		if opts.AdditionalTokenAddress != "" {
-			q.Add("address", opts.AdditionalTokenAddress)
+		if opts.Sort != "" {
+			q.Add("sort", opts.Sort)
 		}
-		if opts.Reorder {
-			q.Add("reorder", "true")
+		if opts.Cursor != "" {
+			q.Add("cursor", opts.Cursor)
 		}
 	}
 	req.URL.RawQuery = q.Encode()
@@ -135,6 +149,11 @@ func (s *TokensService) GetPools(ctx context.Context, networkID, tokenAddress st
 		return nil, err
 	}
 	defer r.Body.Close()
+
+	// /pools/search returns rows under "results"; expose them via .Pools.
+	if len(response.Pools) == 0 {
+		response.Pools = response.Results
+	}
 
 	return &response, nil
 }

--- a/dexpaprika/tokens_test.go
+++ b/dexpaprika/tokens_test.go
@@ -102,58 +102,61 @@ func TestTokens_GetPools(t *testing.T) {
 	}
 }
 
-func TestTokens_GetPoolsWithPair(t *testing.T) {
+func TestTokens_GetPoolsCursorPagination(t *testing.T) {
 	// Create a client with test settings
 	client := NewClient(
 		WithRetryConfig(1, 1*time.Second, 2*time.Second),
 	)
 
 	// Create a context with timeout
-	ctx, cancel := context.WithTimeout(context.Background(), 10*time.Second)
+	ctx, cancel := context.WithTimeout(context.Background(), 20*time.Second)
 	defer cancel()
 
-	// Test token pair pools (WETH-USDC on Ethereum)
 	tokenChain := "ethereum"
 	// #nosec G101
 	tokenAddress := "0xc02aaa39b223fe8d0a0e5c4f27ead9083c756cc2" // WETH
-	// #nosec G101
-	pairTokenAddress := "0xa0b86991c6218b36c1d19d4a2e9eb0ce3606eb48" // USDC
 
-	// Get pools for the token pair
-	opts := &TokenPoolsOptions{
-		ListOptions: &ListOptions{
-			Limit:   5,
-			OrderBy: "volume_usd",
-			Sort:    "desc",
-		},
-		AdditionalTokenAddress: pairTokenAddress,
-	}
-
-	pairPools, err := client.Tokens.GetPools(ctx, tokenChain, tokenAddress, opts)
+	// The deprecated pair/reorder options must be ignored, not sent upstream.
+	firstPage, err := client.Tokens.GetPools(ctx, tokenChain, tokenAddress, &TokenPoolsOptions{
+		ListOptions:            &ListOptions{Limit: 2},
+		AdditionalTokenAddress: "0xa0b86991c6218b36c1d19d4a2e9eb0ce3606eb48", // #nosec G101
+		Reorder:                true,
+	})
 	if err != nil {
-		t.Fatalf("Tokens.GetPools (with pair) returned error: %v", err)
+		t.Fatalf("Tokens.GetPools returned error: %v", err)
+	}
+	if len(firstPage.Pools) == 0 {
+		t.Fatal("Tokens.GetPools returned empty first page, expected pools for WETH")
+	}
+	if !firstPage.HasNextPage || firstPage.NextCursor == nil || *firstPage.NextCursor == "" {
+		t.Fatal("Tokens.GetPools first page has no next cursor, expected more WETH pools")
 	}
 
-	if pairPools == nil {
-		t.Fatal("Tokens.GetPools (with pair) returned nil, expected a PoolList")
+	// Follow the cursor and make sure we get a different page.
+	secondPage, err := client.Tokens.GetPools(ctx, tokenChain, tokenAddress, &TokenPoolsOptions{
+		ListOptions: &ListOptions{Limit: 2, Cursor: *firstPage.NextCursor},
+	})
+	if err != nil {
+		t.Fatalf("Tokens.GetPools (cursor) returned error: %v", err)
+	}
+	if len(secondPage.Pools) == 0 {
+		t.Fatal("Tokens.GetPools (cursor) returned empty page")
+	}
+	if secondPage.Pools[0].ID == firstPage.Pools[0].ID {
+		t.Errorf("Tokens.GetPools (cursor) returned the same first pool %s, expected the next page", secondPage.Pools[0].ID)
 	}
 
-	// All pools should contain both tokens
-	for _, pool := range pairPools.Pools {
-		firstTokenFound := false
-		secondTokenFound := false
-
+	// Every returned pool must still contain the requested token.
+	for _, pool := range append(firstPage.Pools, secondPage.Pools...) {
+		tokenFound := false
 		for _, token := range pool.Tokens {
 			if token.ID == tokenAddress {
-				firstTokenFound = true
-			}
-			if token.ID == pairTokenAddress {
-				secondTokenFound = true
+				tokenFound = true
+				break
 			}
 		}
-
-		if !firstTokenFound || !secondTokenFound {
-			t.Errorf("Tokens.GetPools (with pair) returned pool without both tokens: %s", pool.ID)
+		if !tokenFound {
+			t.Errorf("Tokens.GetPools returned pool without the specified token: %s", pool.ID)
 		}
 	}
 }


### PR DESCRIPTION
## Why

The API removed `GET /networks/{network}/tokens/{token_address}/pools`. It now returns HTTP 410 with a `replacement` pointing at `/networks/:network/pools/search`, which gained a `token_address` query parameter that restricts results to pools containing that token on that network.

## What changed

- `Tokens.GetPools()` now targets `/networks/{network}/pools/search` with `token_address`. The method signature is unchanged; the response exposes search rows via the existing `.Pools` field plus `HasNextPage`/`NextCursor`.
- Sort fields are normalized through the existing `mapPoolSortField` helper (the search endpoint rejects legacy sort values with HTTP 400). Pagination is cursor based: `Page` is still accepted for source compatibility but not sent; use `ListOptions.Cursor`.
- `TokenPoolsOptions.AdditionalTokenAddress` (pair queries) and `TokenPoolsOptions.Reorder` (pair-perspective flip) are deprecated and no longer sent. The search endpoint has no equivalent for either: repeating `token_address` is last-wins on the API side, not a pair filter. Docs point users at client-side filtering on the pool's `Tokens` field.
- The method doc calls out that the filter is network-scoped only: the cross-network `/pools/search` accepts `token_address` but silently ignores it.
- `PoolsPaginator.ForToken` now pages token pools by cursor (its `secondToken` argument is deprecated and ignored). `CachedClient.GetTokenPools` cache key rebuilt from the params actually sent.
- README example updated, CHANGELOG entry added, version 1.6.0.

## Verification

All checked live against api.dexpaprika.com before pushing:

- The old endpoint returns `{"code":410,"message":"endpoint removed","replacement":"/networks/:network/pools/search"}`.
- `GET /networks/ethereum/pools/search?token_address=0xc02aaa...756cc2&limit=3` returns 3 pools, every one containing WETH, with `has_next_page`/`next_cursor` and default `order_by=volume_usd_24h`.
- `go build ./...`, `go vet ./...` clean.
- Full `go test ./...` run: token-pools tests pass, including the new live cursor-pagination test (`TestTokens_GetPoolsCursorPagination`) which asserts token containment on both pages and that the cursor advances. Three unrelated tests (ListByNetwork, GetOHLCV, Search) hit the API burst limiter (429) during the full run and pass when re-run individually.
