### PR TITLE
README: paginator example still printed the always-zero field

### DIFF
--- a/README.md
+++ b/README.md
@@ -235,10 +235,14 @@ for paginator.HasNextPage() {
     // Process the current page
     pools := paginator.GetCurrentPage()
     for _, pool := range pools {
-        fmt.Printf("Pool: %s on %s (Volume: $%.2f)\n", 
-            pool.DexName, 
-            pool.Chain, 
-            pool.VolumeUSD)
+        vol24h := 0.0
+        if pool.VolumeUSD24h != nil {
+            vol24h = *pool.VolumeUSD24h
+        }
+        fmt.Printf("Pool: %s on %s (24h Volume: $%.2f)\n",
+            pool.DexName,
+            pool.Chain,
+            vol24h)
     }
 }
 ```


### PR DESCRIPTION
Follow-up to #17, which only landed half the fix. The code-block replacement silently failed on trailing whitespace, so the paginator example kept printing `pool.VolumeUSD`, which is never populated for `/pools/search` rows and always renders `$0.00`.

Now matches the pattern the README already uses earlier: `VolumeUSD24h` is a pointer, so nil-guard it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01CjkiGV3q4pN7gUAR8vWRW7