### PR TITLE
Point ListByDex at pools/search now that the DEX pools path returns 410

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,21 @@
 # Changelog
 
+## [Unreleased]
+
+### Breaking Changes
+- **API CHANGE**: DexPaprika removed `GET /networks/{network}/dexes/{dex}/pools` (now HTTP 410). `Pools.ListByDex()` now targets `GET /networks/{network}/pools/search` and sends the DEX as the `dex_name` query parameter. The method signature is unchanged.
+- `dex_name` accepts both the DEX id (`curve`) and the display name (`Curve`). Pass the id, which is what `Networks.ListDexes` returns as `Dex.ID`.
+- Pagination is cursor-based: `ListOptions.Page` is still accepted for source compatibility but is no longer sent; use `ListOptions.Cursor` (read from a response's `NextCursor`) to page. Sort fields are normalized to the canonical 24h names, since the endpoint rejects legacy values with HTTP 400.
+- `PoolsPaginator.ForDex` pages DEX pools by cursor instead of by page number.
+- Rows arrive under `results` rather than `pools`, and there is no `page_info`. `PoolsResponse.PageInfo` is deprecated and stays at its zero value for every pools listing.
+
+### Changed
+- `Pool.VolumeUSD` is deprecated. No pools endpoint returns a bare `volume_usd` any more; the SDK copies `volume_usd_24h` into it so existing callers keep reading a real number. Read `Pool.VolumeUSD24h` in new code.
+- `Pool.Transactions` and the `Pool.LastPriceChangeUSD*` fields are deprecated and no longer populated. Use `Pool.Transactions24h` and the `Pool.PriceChangePercentage*` fields.
+
+### Added
+- `Pool.PriceChangePercentage6h`, which `/pools/search` returns but the SDK was dropping.
+
 ## [1.6.0] - 2026-07-15
 
 ### Breaking Changes

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,7 @@
 
 ### Breaking Changes
 - **API CHANGE**: DexPaprika removed `GET /networks/{network}/dexes/{dex}/pools` (now HTTP 410). `Pools.ListByDex()` now targets `GET /networks/{network}/pools/search` and sends the DEX as the `dex_name` query parameter. The method signature is unchanged.
-- `dex_name` accepts both the DEX id (`curve`) and the display name (`Curve`). Pass the id, which is what `Networks.ListDexes` returns as `Dex.ID`.
+- Despite its name, `dex_name` matches the DEX **id** (case-insensitively), which is what `Networks.ListDexes` returns as `Dex.ID`. Passing a human display name such as `Uniswap V3` (the `Dex.Name` field) returns HTTP 200 with an empty result set instead of an error, so a wrong value here fails silently.
 - Pagination is cursor-based: `ListOptions.Page` is still accepted for source compatibility but is no longer sent; use `ListOptions.Cursor` (read from a response's `NextCursor`) to page. Sort fields are normalized to the canonical 24h names, since the endpoint rejects legacy values with HTTP 400.
 - `PoolsPaginator.ForDex` pages DEX pools by cursor instead of by page number.
 - Rows arrive under `results` rather than `pools`, and there is no `page_info`. `PoolsResponse.PageInfo` is deprecated and stays at its zero value for every pools listing.

--- a/README.md
+++ b/README.md
@@ -307,8 +307,15 @@ networkPools, err := client.Pools.ListByNetwork(ctx, "ethereum", &dexpaprika.Lis
     Sort:    "desc",
 })
 
-// Get pools on a specific DEX
-dexPools, err := client.Pools.ListByDex(ctx, "ethereum", "uniswap_v3", opts)
+// Get pools on a specific DEX.
+// /networks/{network}/dexes/{dex}/pools was removed (HTTP 410), so this now
+// targets /pools/search with a dex_name filter. It is cursor-paginated: pass
+// Cursor (from a response's NextCursor) to fetch the next page.
+dexPools, err := client.Pools.ListByDex(ctx, "ethereum", "uniswap_v3", &dexpaprika.ListOptions{
+    Limit:   10,
+    OrderBy: "volume_usd_24h",
+    Sort:    "desc",
+})
 
 // Get details about a specific pool
 poolDetails, err := client.Pools.GetDetails(ctx, "ethereum", "0xpool_address", false)
@@ -324,6 +331,21 @@ ohlcv, err := client.Pools.GetOHLCV(ctx, "ethereum", "0xpool_address", &dexpapri
 // Get transactions for a pool
 transactions, err := client.Pools.GetTransactions(ctx, "ethereum", "0xpool_address", 0, 10, "")
 ```
+
+Note on DEX pools: the API removed `/networks/{network}/dexes/{dex}/pools` and it
+now answers HTTP 410. `Pools.ListByDex` keeps the same signature but sends the DEX
+as the `dex_name` filter on `/networks/{network}/pools/search`. Two consequences
+for callers:
+
+- Pagination is cursor-based. `Page` is ignored, use `Cursor` and read
+  `HasNextPage` / `NextCursor`.
+- The response has no bare `volume_usd`. Read `VolumeUSD24h`. The SDK copies it
+  into the deprecated `VolumeUSD` field so older code keeps working, but
+  `Transactions` and the `LastPriceChangeUSD*` fields are no longer sent at all;
+  use `Transactions24h` and the `PriceChangePercentage*` fields.
+
+`dex_name` accepts either the DEX id (`curve`) or the display name (`Curve`).
+Prefer the id, which is what `Networks.ListDexes` returns as `Dex.ID`.
 
 ### Tokens
 

--- a/README.md
+++ b/README.md
@@ -344,8 +344,11 @@ for callers:
   `Transactions` and the `LastPriceChangeUSD*` fields are no longer sent at all;
   use `Transactions24h` and the `PriceChangePercentage*` fields.
 
-`dex_name` accepts either the DEX id (`curve`) or the display name (`Curve`).
-Prefer the id, which is what `Networks.ListDexes` returns as `Dex.ID`.
+Despite its name, `dex_name` matches the DEX id, case-insensitively: `curve`,
+`CURVE` and `uniswap_v3` all work. It does not match the human display name.
+Pass `Dex.ID` from `Networks.ListDexes`, never `Dex.Name`: a display name such as
+`Uniswap V3` returns HTTP 200 with an empty result set instead of an error, so
+the mistake looks like a DEX with no pools.
 
 ### Tokens
 

--- a/dexpaprika/comprehensive_test.go
+++ b/dexpaprika/comprehensive_test.go
@@ -69,14 +69,6 @@ func TestAllEndpoints(t *testing.T) {
 				"page_info": createPageInfo(50, 0, 2, 100),
 			})
 
-		case "/networks/ethereum/dexes/uniswap_v2/pools":
-			writeTestJSON(w, map[string]interface{}{
-				"pools": []map[string]interface{}{
-					createMockPool("0xb4e16d0168e52d35cacd2c6185b44281ec28c9dc", "ethereum"),
-				},
-				"page_info": createPageInfo(25, 0, 1, 100),
-			})
-
 		case "/networks/ethereum/pools/0xb4e16d0168e52d35cacd2c6185b44281ec28c9dc":
 			writeTestJSON(w, createMockPoolDetails("0xb4e16d0168e52d35cacd2c6185b44281ec28c9dc", "ethereum"))
 
@@ -127,18 +119,28 @@ func TestAllEndpoints(t *testing.T) {
 			writeTestJSON(w, createMockToken("0xa0b86991c6218b36c1d19d4a2e9eb0ce3606eb48", "ethereum"))
 
 		case "/networks/ethereum/pools/search":
-			// Token pools now go through /pools/search with token_address.
-			if r.URL.Query().Get("token_address") != "0xa0b86991c6218b36c1d19d4a2e9eb0ce3606eb48" {
+			// Token pools and DEX pools now both go through /pools/search, the
+			// first filtered by token_address and the second by dex_name.
+			switch {
+			case r.URL.Query().Get("token_address") == "0xa0b86991c6218b36c1d19d4a2e9eb0ce3606eb48":
+				writeTestJSON(w, map[string]interface{}{
+					"results": []map[string]interface{}{
+						createMockSearchPool("0xb4e16d0168e52d35cacd2c6185b44281ec28c9dc", "ethereum", "uniswap_v2", "Uniswap V2"),
+					},
+					"has_next_page": false,
+					"next_cursor":   "",
+				})
+			case r.URL.Query().Get("dex_name") == "uniswap_v2":
+				writeTestJSON(w, map[string]interface{}{
+					"results": []map[string]interface{}{
+						createMockSearchPool("0xb4e16d0168e52d35cacd2c6185b44281ec28c9dc", "ethereum", "uniswap_v2", "Uniswap V2"),
+					},
+					"has_next_page": false,
+					"next_cursor":   "",
+				})
+			default:
 				w.WriteHeader(http.StatusBadRequest)
-				return
 			}
-			writeTestJSON(w, map[string]interface{}{
-				"results": []map[string]interface{}{
-					createMockPool("0xb4e16d0168e52d35cacd2c6185b44281ec28c9dc", "ethereum"),
-				},
-				"has_next_page": false,
-				"next_cursor":   "",
-			})
 
 		// Search endpoint
 		case "/search":
@@ -217,8 +219,8 @@ func TestAllEndpoints(t *testing.T) {
 		testGetNetworkPools(t, ctx, client)
 	})
 
-	t.Run("GetDexPools", func(t *testing.T) {
-		testGetDexPools(t, ctx, client)
+	t.Run("GetDexPoolsViaPoolsSearch", func(t *testing.T) {
+		testGetDexPoolsViaPoolsSearch(t, ctx, client)
 	})
 
 	t.Run("GetPoolDetails", func(t *testing.T) {
@@ -335,8 +337,10 @@ func testGetNetworkPools(t *testing.T, ctx context.Context, client *Client) {
 	}
 }
 
-func testGetDexPools(t *testing.T, ctx context.Context, client *Client) {
-	req, err := client.NewRequest(http.MethodGet, "/networks/ethereum/dexes/uniswap_v2/pools", nil)
+func testGetDexPoolsViaPoolsSearch(t *testing.T, ctx context.Context, client *Client) {
+	// /networks/{network}/dexes/{dex}/pools was removed (HTTP 410). DEX pools
+	// come from /pools/search with dex_name, under "results".
+	req, err := client.NewRequest(http.MethodGet, "/networks/ethereum/pools/search?dex_name=uniswap_v2", nil)
 	if err != nil {
 		t.Fatalf("Failed to create request: %v", err)
 	}
@@ -350,9 +354,12 @@ func testGetDexPools(t *testing.T, ctx context.Context, client *Client) {
 		defer httpResp.Body.Close()
 	}
 
-	pools, ok := resp["pools"].([]interface{})
+	pools, ok := resp["results"].([]interface{})
 	if !ok || len(pools) != 1 {
-		t.Errorf("Expected 1 pool, got %v", pools)
+		t.Errorf("Expected 1 pool under results, got %v", pools)
+	}
+	if _, ok := resp["page_info"]; ok {
+		t.Error("pools/search must not carry page_info")
 	}
 }
 
@@ -528,6 +535,44 @@ func createMockPool(id string, chain string) map[string]interface{} {
 				"chain":    chain,
 				"decimals": 18,
 				"added_at": "2024-12-02T13:00:16.000Z",
+			},
+		},
+	}
+}
+
+// createMockSearchPool mirrors a row from /networks/{network}/pools/search.
+// The field set is copied from a live response captured on 2026-08-05: no bare
+// "volume_usd", no "transactions", 24h volume under "volume_usd_24h", and the
+// price moves under "price_change_percentage_*".
+func createMockSearchPool(id, chain, dexID, dexName string) map[string]interface{} {
+	return map[string]interface{}{
+		"id":                          id,
+		"dex_id":                      dexID,
+		"dex_name":                    dexName,
+		"chain":                       chain,
+		"volume_usd_24h":              15883391.558251368,
+		"created_at":                  "2025-01-25T17:20:47Z",
+		"created_at_block_number":     21702976,
+		"transactions_24h":            289,
+		"price_usd":                   0.9995787501356217,
+		"price_change_percentage_5m":  nil,
+		"price_change_percentage_1h":  0.02422482089565938,
+		"price_change_percentage_6h":  0.009802157529374174,
+		"price_change_percentage_24h": 0.007018797950998323,
+		"fee":                         nil,
+		"volume_usd_7d":               31781851.73428885,
+		"volume_usd_30d":              136889876.39037386,
+		"liquidity_usd":               7407910.088430515,
+		"tokens": []map[string]interface{}{
+			{
+				"id":        "0xa0b86991c6218b36c1d19d4a2e9eb0ce3606eb48",
+				"chain":     chain,
+				"has_image": true,
+			},
+			{
+				"id":        "0xdac17f958d2ee523a2206206994597c13d831ec7",
+				"chain":     chain,
+				"has_image": true,
 			},
 		},
 	}

--- a/dexpaprika/pagination.go
+++ b/dexpaprika/pagination.go
@@ -20,15 +20,8 @@ type PoolsPaginator struct {
 	secondToken string // Optional, for filtering token pairs
 	options     *ListOptions
 	currentResp *PoolsResponse
-	cursor      string // Cursor for the cursor-paginated network /pools/search endpoint
+	cursor      string // Cursor for the cursor-paginated /pools/search endpoint
 	err         error
-}
-
-// isNetworkSearch reports whether this paginator fetches pools via the
-// cursor-paginated /pools/search endpoint (network pools and token pools, as
-// opposed to the page-based DEX-pool endpoint).
-func (p *PoolsPaginator) isNetworkSearch() bool {
-	return p.networkID != "" && p.dexID == ""
 }
 
 // NewPoolsPaginator creates a new paginator for pools
@@ -51,7 +44,10 @@ func (p *PoolsPaginator) ForNetwork(networkID string) *PoolsPaginator {
 	return p
 }
 
-// ForDex sets the paginator to fetch pools for a specific DEX on a network
+// ForDex sets the paginator to fetch pools for a specific DEX on a network.
+//
+// dexID is sent as the dex_name filter on /pools/search, which accepts both the
+// DEX id ("curve") and the display name ("Curve"). Prefer the id.
 func (p *PoolsPaginator) ForDex(networkID, dexID string) *PoolsPaginator {
 	p.networkID = networkID
 	p.dexID = dexID
@@ -80,23 +76,10 @@ func (p *PoolsPaginator) HasNextPage() bool {
 		return false
 	}
 
-	// The network /pools/search endpoint is cursor-paginated and reports whether
-	// more pages exist directly.
-	if p.isNetworkSearch() {
-		return p.currentResp.HasNextPage
-	}
-
-	// Check if we've received fewer items than requested, indicating last page
-	if len(p.currentResp.Pools) < p.options.Limit {
-		return false
-	}
-
-	// Or if the API explicitly tells us there are no more pages
-	if p.currentResp.PageInfo.Page+1 >= p.currentResp.PageInfo.TotalPages {
-		return false
-	}
-
-	return true
+	// Network pools, DEX pools and token pools all read from the cursor-paginated
+	// /pools/search endpoint, whose envelope reports directly whether more pages
+	// exist. No pools path is page-based any more.
+	return p.currentResp.HasNextPage
 }
 
 // GetNextPage fetches the next page of results
@@ -118,10 +101,8 @@ func (p *PoolsPaginator) GetNextPage(ctx context.Context) error {
 		}
 		resp, err = p.client.Tokens.GetPools(ctx, p.networkID, p.tokenID, tokenOpts)
 	case p.dexID != "":
-		// DEX pools (page-based)
-		if p.currentResp != nil {
-			p.options.Page++
-		}
+		// DEX pools (cursor-based /pools/search with dex_name)
+		p.options.Cursor = p.cursor
 		resp, err = p.client.Pools.ListByDex(ctx, p.networkID, p.dexID, p.options)
 	case p.networkID != "":
 		// Network pools (cursor-based /pools/search)
@@ -140,13 +121,11 @@ func (p *PoolsPaginator) GetNextPage(ctx context.Context) error {
 
 	p.currentResp = resp
 
-	// Track the cursor for the next page of a network search.
-	if p.isNetworkSearch() {
-		if resp != nil && resp.NextCursor != nil {
-			p.cursor = *resp.NextCursor
-		} else {
-			p.cursor = ""
-		}
+	// Track the cursor for the next page.
+	if resp != nil && resp.NextCursor != nil {
+		p.cursor = *resp.NextCursor
+	} else {
+		p.cursor = ""
 	}
 
 	return nil

--- a/dexpaprika/pagination.go
+++ b/dexpaprika/pagination.go
@@ -46,8 +46,9 @@ func (p *PoolsPaginator) ForNetwork(networkID string) *PoolsPaginator {
 
 // ForDex sets the paginator to fetch pools for a specific DEX on a network.
 //
-// dexID is sent as the dex_name filter on /pools/search, which accepts both the
-// DEX id ("curve") and the display name ("Curve"). Prefer the id.
+// dexID is sent as the dex_name filter on /pools/search, which matches the DEX
+// id case-insensitively. Pass Dex.ID from Networks.ListDexes ("uniswap_v3"), not
+// Dex.Name ("Uniswap V3"): a display name yields an empty result set, not an error.
 func (p *PoolsPaginator) ForDex(networkID, dexID string) *PoolsPaginator {
 	p.networkID = networkID
 	p.dexID = dexID

--- a/dexpaprika/pools.go
+++ b/dexpaprika/pools.go
@@ -216,9 +216,11 @@ func (s *PoolsService) ListByNetwork(ctx context.Context, networkID string, opts
 //
 // The DexPaprika API removed /networks/{network}/dexes/{dex}/pools (HTTP 410),
 // so this method targets the unified /networks/{network}/pools/search endpoint
-// and passes the DEX through the dex_name query parameter. dex_name resolves
-// both the DEX id ("curve") and the display name ("Curve"); prefer the id,
-// which is what Networks.ListDexes returns as Dex.ID.
+// and passes the DEX through the dex_name query parameter. Despite that name,
+// the filter matches the DEX id, case-insensitively, so dexID must be what
+// Networks.ListDexes returns as Dex.ID ("uniswap_v3"), not Dex.Name
+// ("Uniswap V3"). A display name returns HTTP 200 with an empty result set
+// rather than an error, so a wrong value here fails silently.
 //
 // That endpoint is cursor-paginated and rejects the legacy sort values, so the
 // sort field is normalized and the Page option is not sent upstream. Pass

--- a/dexpaprika/pools.go
+++ b/dexpaprika/pools.go
@@ -76,13 +76,12 @@ type Pool struct {
 // /pools/search returns rows under "results" with cursor-based
 // HasNextPage/NextCursor. ListByNetwork, ListByDex and Tokens.GetPools all copy
 // those rows into Pools so callers keep reading .Pools.
-//
-// Deprecated: PageInfo. The removed page-based pools endpoints filled it; the
-// search endpoint sends no page_info, so it is always the zero value. Page with
-// Cursor and HasNextPage instead.
 type PoolsResponse struct {
-	Pools       []Pool   `json:"pools"`
-	Results     []Pool   `json:"results,omitempty"`
+	Pools   []Pool `json:"pools"`
+	Results []Pool `json:"results,omitempty"`
+	// Deprecated: the removed page-based pools endpoints filled this; the search
+	// endpoint sends no page_info, so it is always the zero value. Page with
+	// Cursor and HasNextPage instead.
 	PageInfo    PageInfo `json:"page_info"`
 	HasNextPage bool     `json:"has_next_page,omitempty"`
 	NextCursor  *string  `json:"next_cursor,omitempty"`
@@ -107,10 +106,10 @@ func normalizePoolsResponse(resp *PoolsResponse) {
 }
 
 // ListOptions contains common options for listing pools.
-//
-// Deprecated: Page. Every pools listing now targets the cursor-paginated
-// /pools/search endpoint, which ignores it; use Cursor to fetch the next page.
 type ListOptions struct {
+	// Deprecated: every pools listing now targets the cursor-paginated
+	// /pools/search endpoint, which ignores this field. Use Cursor to fetch the
+	// next page.
 	Page    int
 	Limit   int
 	Sort    string

--- a/dexpaprika/pools.go
+++ b/dexpaprika/pools.go
@@ -31,25 +31,35 @@ type Token struct {
 }
 
 // Pool represents a liquidity pool.
+//
+// Every pools listing in this SDK now reads from /networks/{network}/pools/search,
+// so the field set below is the one that endpoint returns. The fields marked
+// Deprecated came from endpoints that have been removed and are no longer on the
+// wire; see the notes on each.
 type Pool struct {
-	ID                    string   `json:"id"`
-	DexID                 string   `json:"dex_id"`
-	DexName               string   `json:"dex_name"`
-	Chain                 string   `json:"chain"`
-	VolumeUSD             float64  `json:"volume_usd"`
-	CreatedAt             string   `json:"created_at"`
-	CreatedAtBlockNumber  int64    `json:"created_at_block_number"`
-	Transactions          int      `json:"transactions"`
-	PriceUSD              float64  `json:"price_usd"`
+	ID      string `json:"id"`
+	DexID   string `json:"dex_id"`
+	DexName string `json:"dex_name"`
+	Chain   string `json:"chain"`
+	// Deprecated: no pools endpoint returns a bare "volume_usd" any more.
+	// /pools/search reports 24h volume as VolumeUSD24h, which the SDK copies
+	// into this field so existing callers keep reading a real number instead of
+	// a silent zero. Read VolumeUSD24h in new code.
+	VolumeUSD            float64 `json:"volume_usd"`
+	CreatedAt            string  `json:"created_at"`
+	CreatedAtBlockNumber int64   `json:"created_at_block_number"`
+	// Deprecated: /pools/search returns Transactions24h instead. This field
+	// stays zero.
+	Transactions int     `json:"transactions"`
+	PriceUSD     float64 `json:"price_usd"`
+	// Deprecated: /pools/search returns the PriceChangePercentage* fields
+	// instead. These stay nil.
 	LastPriceChangeUSD5m  *float64 `json:"last_price_change_usd_5m"`
 	LastPriceChangeUSD1h  *float64 `json:"last_price_change_usd_1h"`
 	LastPriceChangeUSD24h *float64 `json:"last_price_change_usd_24h"`
 	Fee                   *float64 `json:"fee"`
 	Tokens                []Token  `json:"tokens"`
-	// VolumeUSD/Transactions/LastPriceChangeUSD* are returned by the DEX-pools and
-	// token-pools endpoints. The /pools/search endpoint instead returns the
-	// timeframe-split and percentage-named fields below; whichever endpoint
-	// produced this value leaves the other set nil/zero.
+
 	VolumeUSD24h             *float64 `json:"volume_usd_24h,omitempty"`
 	VolumeUSD7d              *float64 `json:"volume_usd_7d,omitempty"`
 	VolumeUSD30d             *float64 `json:"volume_usd_30d,omitempty"`
@@ -57,15 +67,19 @@ type Pool struct {
 	Transactions24h          int      `json:"transactions_24h,omitempty"`
 	PriceChangePercentage5m  *float64 `json:"price_change_percentage_5m,omitempty"`
 	PriceChangePercentage1h  *float64 `json:"price_change_percentage_1h,omitempty"`
+	PriceChangePercentage6h  *float64 `json:"price_change_percentage_6h,omitempty"`
 	PriceChangePercentage24h *float64 `json:"price_change_percentage_24h,omitempty"`
 }
 
 // PoolsResponse represents the response for the pools endpoints.
 //
-// The DEX-pools and token-pools endpoints return rows under "pools" with
-// page-based PageInfo. The /pools/search endpoint (used by ListByNetwork)
-// returns rows under "results" with cursor-based HasNextPage/NextCursor;
-// ListByNetwork copies those rows into Pools so callers keep reading .Pools.
+// /pools/search returns rows under "results" with cursor-based
+// HasNextPage/NextCursor. ListByNetwork, ListByDex and Tokens.GetPools all copy
+// those rows into Pools so callers keep reading .Pools.
+//
+// Deprecated: PageInfo. The removed page-based pools endpoints filled it; the
+// search endpoint sends no page_info, so it is always the zero value. Page with
+// Cursor and HasNextPage instead.
 type PoolsResponse struct {
 	Pools       []Pool   `json:"pools"`
 	Results     []Pool   `json:"results,omitempty"`
@@ -74,10 +88,28 @@ type PoolsResponse struct {
 	NextCursor  *string  `json:"next_cursor,omitempty"`
 }
 
+// normalizePoolsResponse adapts a /pools/search payload to the field names
+// older callers read. The endpoint returns rows under "results" rather than
+// "pools", and reports 24h volume as "volume_usd_24h" rather than the bare
+// "volume_usd" the removed endpoints used, so both legacy names are backfilled.
+func normalizePoolsResponse(resp *PoolsResponse) {
+	if resp == nil {
+		return
+	}
+	if len(resp.Pools) == 0 {
+		resp.Pools = resp.Results
+	}
+	for i := range resp.Pools {
+		if resp.Pools[i].VolumeUSD == 0 && resp.Pools[i].VolumeUSD24h != nil {
+			resp.Pools[i].VolumeUSD = *resp.Pools[i].VolumeUSD24h
+		}
+	}
+}
+
 // ListOptions contains common options for listing pools.
 //
-// Page is honored only by the legacy/DEX-pool endpoints. The cursor-paginated
-// /pools/search endpoint ignores Page; use Cursor to fetch the next page.
+// Deprecated: Page. Every pools listing now targets the cursor-paginated
+// /pools/search endpoint, which ignores it; use Cursor to fetch the next page.
 type ListOptions struct {
 	Page    int
 	Limit   int
@@ -100,36 +132,6 @@ func validatePoolAddress(poolAddress string) error {
 		return fmt.Errorf("pool address is required")
 	}
 	return nil
-}
-
-// addOptions adds the parameters in opts as URL query parameters to s.
-func addOptions(s string, opts interface{}) (string, error) {
-	v := url.Values{}
-
-	if o, ok := opts.(*ListOptions); ok {
-		if o.Page > 0 {
-			v.Add("page", fmt.Sprintf("%d", o.Page))
-		}
-		if o.Limit > 0 {
-			// Validate limit constraints (max 100 as per API v1.3.0)
-			limit := o.Limit
-			if limit > 100 {
-				limit = 100
-			}
-			v.Add("limit", fmt.Sprintf("%d", limit))
-		}
-		if o.Sort != "" {
-			v.Add("sort", o.Sort)
-		}
-		if o.OrderBy != "" {
-			v.Add("order_by", o.OrderBy)
-		}
-	}
-
-	if len(v) > 0 {
-		return s + "?" + v.Encode(), nil
-	}
-	return s, nil
 }
 
 // List returns a list of top pools from all networks.
@@ -206,16 +208,22 @@ func (s *PoolsService) ListByNetwork(ctx context.Context, networkID string, opts
 	}
 	defer r.Body.Close()
 
-	// /pools/search returns rows under "results"; expose them via .Pools.
-	if len(response.Pools) == 0 {
-		response.Pools = response.Results
-	}
+	normalizePoolsResponse(&response)
 
 	return &response, nil
 }
 
 // ListByDex returns a list of top pools on a specific network's DEX.
-// Implements the getDexPools operation from the OpenAPI spec.
+//
+// The DexPaprika API removed /networks/{network}/dexes/{dex}/pools (HTTP 410),
+// so this method targets the unified /networks/{network}/pools/search endpoint
+// and passes the DEX through the dex_name query parameter. dex_name resolves
+// both the DEX id ("curve") and the display name ("Curve"); prefer the id,
+// which is what Networks.ListDexes returns as Dex.ID.
+//
+// That endpoint is cursor-paginated and rejects the legacy sort values, so the
+// sort field is normalized and the Page option is not sent upstream. Pass
+// ListOptions.Cursor (taken from a previous response's NextCursor) to page.
 func (s *PoolsService) ListByDex(ctx context.Context, networkID, dexID string, opts *ListOptions) (*PoolsResponse, error) {
 	if err := validateNetworkID(networkID); err != nil {
 		return nil, err
@@ -224,15 +232,34 @@ func (s *PoolsService) ListByDex(ctx context.Context, networkID, dexID string, o
 		return nil, fmt.Errorf("dex ID is required")
 	}
 
-	path, err := addOptions(fmt.Sprintf("/networks/%s/dexes/%s/pools", networkID, dexID), opts)
+	req, err := s.client.NewRequest(http.MethodGet, fmt.Sprintf("/networks/%s/pools/search", networkID), nil)
 	if err != nil {
 		return nil, err
 	}
 
-	req, err := s.client.NewRequest(http.MethodGet, path, nil)
-	if err != nil {
-		return nil, err
+	q := req.URL.Query()
+	q.Add("dex_name", dexID)
+	orderBy := ""
+	if opts != nil {
+		orderBy = opts.OrderBy
 	}
+	q.Add("order_by", mapPoolSortField(orderBy))
+	if opts != nil {
+		if opts.Limit > 0 {
+			limit := opts.Limit
+			if limit > 100 {
+				limit = 100
+			}
+			q.Add("limit", fmt.Sprintf("%d", limit))
+		}
+		if opts.Sort != "" {
+			q.Add("sort", opts.Sort)
+		}
+		if opts.Cursor != "" {
+			q.Add("cursor", opts.Cursor)
+		}
+	}
+	req.URL.RawQuery = q.Encode()
 
 	var response PoolsResponse
 	r, err := s.client.Do(ctx, req, &response)
@@ -240,6 +267,8 @@ func (s *PoolsService) ListByDex(ctx context.Context, networkID, dexID string, o
 		return nil, err
 	}
 	defer r.Body.Close()
+
+	normalizePoolsResponse(&response)
 
 	return &response, nil
 }

--- a/dexpaprika/pools_test.go
+++ b/dexpaprika/pools_test.go
@@ -6,6 +6,7 @@ import (
 	"fmt"
 	"net/http"
 	"net/http/httptest"
+	"net/url"
 	"testing"
 	"time"
 )
@@ -111,12 +112,139 @@ func TestPools_ListByDex(t *testing.T) {
 		t.Fatal("Pools.ListByDex returned nil, expected a PoolList")
 	}
 
-	// All pools should be on the specified network and DEX
+	// All pools should be on the specified network and DEX. The dex_name filter
+	// resolves the DEX id, so every row must carry it back.
 	for _, pool := range pools.Pools {
 		if pool.Chain != networkID {
 			t.Errorf("Pools.ListByDex returned pool with wrong chain: got %s, want %s", pool.Chain, networkID)
 		}
-		// DEX names might not exactly match the DEX ID, so we don't check this strictly
+		if pool.DexID != dexID {
+			t.Errorf("Pools.ListByDex returned pool from the wrong DEX: got %s, want %s", pool.DexID, dexID)
+		}
+	}
+}
+
+// TestPools_ListByDexTargetsPoolsSearch pins the request ListByDex puts on the
+// wire. The old path /networks/{network}/dexes/{dex}/pools returns HTTP 410, so
+// the DEX has to travel as the dex_name query parameter on /pools/search.
+func TestPools_ListByDexTargetsPoolsSearch(t *testing.T) {
+	var gotPath string
+	var gotQuery url.Values
+
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		gotPath = r.URL.Path
+		gotQuery = r.URL.Query()
+		w.Header().Set("Content-Type", "application/json")
+		// Field names copied from a live /pools/search response captured on
+		// 2026-08-05: rows under "results", 24h volume as "volume_usd_24h",
+		// cursor pagination, and no page_info.
+		fmt.Fprint(w, `{"results":[{"id":"0x4f493b7de8aac7d55f71853688b1f7c8f0243c85","dex_id":"curve","dex_name":"Curve","chain":"ethereum","volume_usd_24h":15883391.558251368,"transactions_24h":289,"price_usd":0.9995787501356217,"price_change_percentage_6h":0.009802157529374174,"volume_usd_7d":31781851.73428885,"liquidity_usd":7407910.088430515}],"has_next_page":true,"next_cursor":"eyJjaGFpbiI6ImV0aGVyZXVtIn0","query":{"network":"ethereum","dex_name":"curve"}}`)
+	}))
+	defer server.Close()
+
+	client := NewClient(
+		WithBaseURL(server.URL),
+		WithRetryConfig(0, 1*time.Millisecond, 1*time.Millisecond),
+	)
+	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+	defer cancel()
+
+	resp, err := client.Pools.ListByDex(ctx, "ethereum", "curve", &ListOptions{
+		Limit:   1,
+		Page:    7,
+		OrderBy: "volume_usd",
+		Sort:    "desc",
+	})
+	if err != nil {
+		t.Fatalf("ListByDex returned error: %v", err)
+	}
+
+	if want := "/networks/ethereum/pools/search"; gotPath != want {
+		t.Errorf("ListByDex requested %q, want %q", gotPath, want)
+	}
+	if got := gotQuery.Get("dex_name"); got != "curve" {
+		t.Errorf("dex_name = %q, want %q", got, "curve")
+	}
+	// The legacy page parameter must not travel: /pools/search is cursor-based.
+	if gotQuery.Has("page") {
+		t.Errorf("ListByDex sent page=%q, but /pools/search is cursor-paginated", gotQuery.Get("page"))
+	}
+	// Legacy sort values are rejected upstream with HTTP 400, so order_by is
+	// normalized to the canonical field name.
+	if got := gotQuery.Get("order_by"); got != "volume_usd_24h" {
+		t.Errorf("order_by = %q, want %q", got, "volume_usd_24h")
+	}
+
+	if len(resp.Results) != 1 {
+		t.Fatalf("expected 1 row under Results, got %d", len(resp.Results))
+	}
+	if len(resp.Pools) != 1 {
+		t.Fatalf("expected Results to be exposed via Pools, got %d rows", len(resp.Pools))
+	}
+	pool := resp.Pools[0]
+	if pool.DexID != "curve" {
+		t.Errorf("DexID = %q, want %q", pool.DexID, "curve")
+	}
+	if pool.VolumeUSD24h == nil || *pool.VolumeUSD24h != 15883391.558251368 {
+		t.Errorf("VolumeUSD24h = %v, want 15883391.558251368", pool.VolumeUSD24h)
+	}
+	// volume_usd is gone from the wire; the SDK backfills it from volume_usd_24h
+	// so callers written against the removed endpoint keep reading a real number.
+	if pool.VolumeUSD != 15883391.558251368 {
+		t.Errorf("VolumeUSD = %v, want it backfilled from volume_usd_24h", pool.VolumeUSD)
+	}
+	if pool.Transactions24h != 289 {
+		t.Errorf("Transactions24h = %d, want 289", pool.Transactions24h)
+	}
+	if pool.PriceChangePercentage6h == nil || *pool.PriceChangePercentage6h != 0.009802157529374174 {
+		t.Errorf("PriceChangePercentage6h = %v, want 0.009802157529374174", pool.PriceChangePercentage6h)
+	}
+
+	if !resp.HasNextPage {
+		t.Error("expected HasNextPage to be true")
+	}
+	if resp.NextCursor == nil || *resp.NextCursor != "eyJjaGFpbiI6ImV0aGVyZXVtIn0" {
+		t.Errorf("NextCursor = %v, want the cursor from the envelope", resp.NextCursor)
+	}
+	if resp.PageInfo.TotalPages != 0 {
+		t.Errorf("PageInfo should stay zero, /pools/search sends no page_info, got %+v", resp.PageInfo)
+	}
+}
+
+// TestPools_ListByDexSurfacesGone checks that a 410 from the removed path still
+// reaches the caller as a typed error carrying the replacement endpoint, in case
+// an older SDK build or a proxy is still pointed at it.
+func TestPools_ListByDexSurfacesGone(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		w.WriteHeader(http.StatusGone)
+		fmt.Fprint(w, `{"code":410,"message":"endpoint removed","replacement":"/networks/:network/pools/search"}`)
+	}))
+	defer server.Close()
+
+	client := NewClient(
+		WithBaseURL(server.URL),
+		WithRetryConfig(0, 1*time.Millisecond, 1*time.Millisecond),
+	)
+	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+	defer cancel()
+
+	_, err := client.Pools.ListByDex(ctx, "ethereum", "curve", nil)
+	if err == nil {
+		t.Fatal("expected an error for a 410 response, got nil")
+	}
+	if !errors.Is(err, ErrGone) {
+		t.Errorf("expected errors.Is(err, ErrGone) to be true, got %v", err)
+	}
+	var apiErr *APIError
+	if !errors.As(err, &apiErr) {
+		t.Fatalf("expected an *APIError, got %T", err)
+	}
+	if apiErr.StatusCode != http.StatusGone {
+		t.Errorf("expected status code 410, got %d", apiErr.StatusCode)
+	}
+	if apiErr.Replacement != "/networks/:network/pools/search" {
+		t.Errorf("Replacement = %q, want the endpoint from the response body", apiErr.Replacement)
 	}
 }
 

--- a/dexpaprika/tokens.go
+++ b/dexpaprika/tokens.go
@@ -150,10 +150,7 @@ func (s *TokensService) GetPools(ctx context.Context, networkID, tokenAddress st
 	}
 	defer r.Body.Close()
 
-	// /pools/search returns rows under "results"; expose them via .Pools.
-	if len(response.Pools) == 0 {
-		response.Pools = response.Results
-	}
+	normalizePoolsResponse(&response)
 
 	return &response, nil
 }


### PR DESCRIPTION
The API removed `GET /networks/{network}/dexes/{dex}/pools`. It answers HTTP 410 today, with a body pointing at `/networks/:network/pools/search`. I confirmed both directions on 2026-08-05: the old path returns 410 for a real DEX slug and for a nonsense one, so the route itself is gone, and the new path returns 200.

`Pools.ListByDex` was calling the removed path, so every caller got a 410. It now calls `/networks/{network}/pools/search` and sends the DEX as the `dex_name` query parameter. The method signature is unchanged, so no caller has to touch its call site.

`dex_name` accepts both the DEX id (`curve`) and the display name (`Curve`). I pass the id through, which is what `Networks.ListDexes` already returns as `Dex.ID`. I verified the parameter actually binds rather than being silently dropped: `?dex_name=curve` comes back with every row on `dex_id` `curve`, while a garbage-named control parameter returns the unfiltered baseline byte for byte.

## What changes for callers

The replacement endpoint has a different response shape, so a few things move even though the signature does not.

- Rows arrive under `results`, not `pools`. `ListByDex` copies them into `.Pools` as well, so existing code keeps working.
- Pagination is cursor based. `ListOptions.Page` is still accepted but is no longer sent; use `Cursor` and read `HasNextPage` and `NextCursor`. `PoolsResponse.PageInfo` is now always the zero value, since the endpoint sends no `page_info`. I marked it deprecated.
- The 24h volume field is `volume_usd_24h`. There is no bare `volume_usd` on the wire any more. I backfill `Pool.VolumeUSD` from it so callers reading that field see a real number instead of a silent zero, and marked the field deprecated in favour of `Pool.VolumeUSD24h`.
- `Pool.Transactions` and the `Pool.LastPriceChangeUSD*` fields are no longer sent by any pools endpoint. They are deprecated. Use `Pool.Transactions24h` and the `Pool.PriceChangePercentage*` fields.

`PoolsPaginator.ForDex` was paging by incrementing a page number, which the search endpoint ignores, so it would have looped on page one forever. It now pages by cursor like the network and token paginators.

While reading the live response against the SDK types I found `price_change_percentage_6h` coming back on every row with no field to land in, so I added `Pool.PriceChangePercentage6h`.

## Verification

Both directions, on the live API:

```
GET /networks/ethereum/dexes/uniswap_v3/pools?limit=2   -> 410 {"code":410,"message":"endpoint removed","replacement":"/networks/:network/pools/search"}
GET /networks/ethereum/pools/search?limit=2&dex_name=curve -> 200, both rows dex_id "curve"
```

Test suite, on this branch:

```
ok  	github.com/coinpaprika/dexpaprika-sdk-go/dexpaprika	23.022s
ok  	github.com/coinpaprika/dexpaprika-sdk-go/tests	3.386s
```

Before the change, the same suite failed on `TestPools_ListByDex` and `TestPoolsPaginator_ForDex`, both with the 410. `make run-example` and `go build` both pass.

I added `TestPools_ListByDexTargetsPoolsSearch`, which pins the request the SDK puts on the wire: the path is `/networks/ethereum/pools/search`, `dex_name` carries the DEX, `page` is not sent, and `order_by` is normalized to `volume_usd_24h`. It also checks the response mapping against field names copied from a live capture. `TestPools_ListByDexSurfacesGone` checks that a 410 still reaches the caller as an `*APIError` carrying the replacement path from the body, in case an older build or a proxy is still pointed at the removed path. The live `TestPools_ListByDex` now asserts that every returned pool really is from the requested DEX, which it could not do before because the filter did not exist.

The mock server in `comprehensive_test.go` was serving the removed route, so a test could pass against a shape the API no longer produces. I dropped that route and added a `createMockSearchPool` helper whose field set is copied from a live `/pools/search` response.

## Not in this PR

No tag. This needs one to reach users, since a Go module release is just a tag.
