### PR TITLE
Reach the 6h, 1h and 5m price-change windows on pool search

### DIFF
--- a/dexpaprika/pools.go
+++ b/dexpaprika/pools.go
@@ -5,6 +5,7 @@ import (
 	"fmt"
 	"net/http"
 	"net/url"
+	"strconv"
 )
 
 // PoolsService handles communication with the pools related
@@ -487,6 +488,17 @@ type PoolFilterOptions struct {
 	Txns24hMin    *int
 	CreatedAfter  string
 	CreatedBefore string
+
+	// Price-change bounds, in percent. Negative values are meaningful: set
+	// PriceChange24hMax to -20 to find pools down at least a fifth on the day.
+	PriceChange24hMin *float64
+	PriceChange24hMax *float64
+	PriceChange6hMin  *float64
+	PriceChange6hMax  *float64
+	PriceChange1hMin  *float64
+	PriceChange1hMax  *float64
+	PriceChange5mMin  *float64
+	PriceChange5mMax  *float64
 }
 
 // PoolFilterResponse represents the response from the /pools/search endpoint.
@@ -552,6 +564,20 @@ func (s *PoolsService) Filter(ctx context.Context, networkID string, opts *PoolF
 		}
 		if opts.Txns24hMin != nil {
 			q.Add("txns_24h_min", fmt.Sprintf("%d", *opts.Txns24hMin))
+		}
+		for name, value := range map[string]*float64{
+			"price_change_percentage_24h_min": opts.PriceChange24hMin,
+			"price_change_percentage_24h_max": opts.PriceChange24hMax,
+			"price_change_percentage_6h_min":  opts.PriceChange6hMin,
+			"price_change_percentage_6h_max":  opts.PriceChange6hMax,
+			"price_change_percentage_1h_min":  opts.PriceChange1hMin,
+			"price_change_percentage_1h_max":  opts.PriceChange1hMax,
+			"price_change_percentage_5m_min":  opts.PriceChange5mMin,
+			"price_change_percentage_5m_max":  opts.PriceChange5mMax,
+		} {
+			if value != nil {
+				q.Add(name, strconv.FormatFloat(*value, 'f', -1, 64))
+			}
 		}
 		if opts.CreatedAfter != "" {
 			q.Add("created_after", opts.CreatedAfter)

--- a/dexpaprika/pools_test.go
+++ b/dexpaprika/pools_test.go
@@ -6,6 +6,7 @@ import (
 	"fmt"
 	"net/http"
 	"net/http/httptest"
+	"strings"
 	"testing"
 	"time"
 )
@@ -488,5 +489,71 @@ func TestPools_ValidationErrors(t *testing.T) {
 	_, err = client.Pools.GetTransactions(ctx, "ethereum", "", 0, 10, "")
 	if err == nil || err.Error() != "pool address is required" {
 		t.Errorf("Expected 'pool address is required' error, got: %v", err)
+	}
+}
+
+// TestPools_FilterSendsPriceChangeBounds pins the wire format of the
+// price-change filters. They are worth a test because a mistake here is
+// invisible from the response: /pools/search ignores query parameters it does
+// not recognize and answers 200, so a misspelled or dropped bound returns a
+// full, plausible, unfiltered result set.
+func TestPools_FilterSendsPriceChangeBounds(t *testing.T) {
+	var got string
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		got = r.URL.RawQuery
+		w.Header().Set("Content-Type", "application/json")
+		fmt.Fprint(w, `{"results":[],"has_next_page":false}`)
+	}))
+	defer server.Close()
+
+	client := NewClient(
+		WithBaseURL(server.URL),
+		WithRetryConfig(0, 1*time.Millisecond, 1*time.Millisecond),
+	)
+	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+	defer cancel()
+
+	min1h := 50.0
+	max5m := -20.0
+	_, err := client.Pools.Filter(ctx, "ethereum", &PoolFilterOptions{
+		SortBy:           "price_change_percentage_1h",
+		PriceChange1hMin: &min1h,
+		PriceChange5mMax: &max5m,
+	})
+	if err != nil {
+		t.Fatalf("Filter returned error: %v", err)
+	}
+
+	for _, want := range []string{
+		"order_by=price_change_percentage_1h",
+		"price_change_percentage_1h_min=50",
+		// Negative bounds are the whole point of a max on a price change, and
+		// they are also where a naive %f formatter would produce -20.000000.
+		"price_change_percentage_5m_max=-20",
+	} {
+		if !strings.Contains(got, want) {
+			t.Errorf("query %q is missing %q", got, want)
+		}
+	}
+}
+
+// TestSortFieldWindowsArePoolOnly guards the asymmetry between the two search
+// endpoints. Verified against api.dexpaprika.com on 2026-08-07: /pools/search
+// lists the three shorter windows in its 400 body, /tokens/search does not, and
+// token rows carry no price_change_percentage_5m field at all. Sending one to
+// tokens/search is a 400, so the fallback to volume_usd_24h is the correct
+// behaviour rather than an oversight.
+func TestSortFieldWindowsArePoolOnly(t *testing.T) {
+	for _, field := range []string{
+		"price_change_percentage_6h",
+		"price_change_percentage_1h",
+		"price_change_percentage_5m",
+	} {
+		if got := mapPoolSortField(field); got != field {
+			t.Errorf("mapPoolSortField(%q) = %q, want it passed through", field, got)
+		}
+		if got := mapTokenSortField(field); got != "volume_usd_24h" {
+			t.Errorf("mapTokenSortField(%q) = %q, want the volume_usd_24h fallback", field, got)
+		}
 	}
 }

--- a/dexpaprika/search_mapping.go
+++ b/dexpaprika/search_mapping.go
@@ -36,7 +36,12 @@ func mapPoolSortField(field string) string {
 		"txns_24h",
 		"created_at",
 		"price_usd",
-		"price_change_percentage_24h":
+		"price_change_percentage_24h",
+		// Shorter windows, pools only. tokens/search does not carry them and
+		// mapTokenSortField deliberately does not list them.
+		"price_change_percentage_6h",
+		"price_change_percentage_1h",
+		"price_change_percentage_5m":
 		return field
 	default:
 		return defaultSearchSortField


### PR DESCRIPTION
`/networks/{network}/pools/search` accepts three shorter price-change windows for both sorting and filtering. The SDK could reach none of them.

## Two gaps, two different silent failures

**Sorting.** `mapPoolSortField` did not list `price_change_percentage_6h`, `_1h` or `_5m` as canonical, so they hit the unknown-field fallback and became `volume_usd_24h`. The caller got 200 and a full result set sorted by something they did not ask for.

**Filtering.** `PoolFilterOptions` had no fields for the bounds, and `Filter` builds its query from named struct fields, so there was no way to pass them at all. Eight fields added, including the 24h pair, which the endpoint already accepted.

## Pools only, deliberately

`tokens/search` rejects these windows with a 400, and token rows carry no `price_change_percentage_5m` field. `mapTokenSortField` keeps falling back to `volume_usd_24h`, and `TestSortFieldWindowsArePoolOnly` pins that asymmetry so a later sweep does not "fix" the token side into breakage.

Related: the 400 body from `tokens/search` advertises `price_usd` in its allowed list, but ordering tokens by `price_usd` still returns 400. The existing remap of `price_usd` to `volume_usd_24h` is therefore still load-bearing and is left alone.

## Formatting

Bounds use `strconv.FormatFloat(v, 'f', -1, 64)` rather than `%f`. A max on a price change is usually negative (down at least 20 percent is `max=-20`), and `%f` would have put `-20.000000` on the wire.

## Verification

Live against `api.dexpaprika.com`:

```
order_by=price_change_percentage_6h&sort=desc -> 2999701460315450, 1278252.46, 33613.16
order_by=price_change_percentage_6h&sort=asc  -> -97.45, -52.76, -45.83
price_change_percentage_1h_min=50             -> 91.46, 1000.14, 2640.80  (all >= 50)
no filter (baseline)                          -> 0, -0.00008, -0.087, -0.038, -0.045
```

The baseline is the control that matters: `pools/search` answers 200 and ignores query parameters it does not recognize, so a dropped bound would still have returned a plausible list. The near-zero baseline is what proves the bound applied.

Both tests were confirmed to fail before the fix, not just to pass after it. Removing the three canonical entries makes the sort test report the `volume_usd_24h` fallback; misspelling one parameter name makes the filter test report it missing from the query.

## Test suite

`go build ./...` clean, new tests pass. Three tests fail on this branch, and all three fail identically on `main` before this change: `TestPools_ListByDex` and `TestPoolsPaginator_ForDex` hit the removed dex-pools endpoint (410), and `TestPoolsService/GetOHLCV` returns empty data from the live API. Worth a separate look, untouched here.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_016Zw5oLXk2fVxkVJvgqrc9j

---

## Correction, added after review

My first pass on this branch called the price-change windows pools-only across the board. That is right for the three short ones and wrong for 24h.

`/networks/{network}/tokens/search` honours `price_change_percentage_24h_min` and `_max`. A follow-up commit on this same branch adds them to the token side, with a test.

Measured on ethereum, and the misspelled control is what makes the rest of it evidence:

```
no filter                                 [95.7, -0.07, 0.23, -0.02, 0.4]
price_change_percentage_24h_min=20        [95.7, 36.62, 15876.53, 22.96, 32.88]
price_change_percentage_24h_max=-20       [-99.41, -22.53, -56.11, -86.58, -27.49]
price_change_pct_24h_min=20 (misspelled)  [95.7, -0.07, 0.23, -0.02, 0.4]
price_change_percentage_6h_min=20         [95.7, -0.07, 0.23, -0.02, 0.4]
```

The last line is the one that keeps the asymmetry honest: the 6h bound on tokens returns the unfiltered baseline, so the short windows really are pool-only. Sorting tokens by any of the three is a 400.

So the accurate statement is narrower than what I wrote first. The three short windows are pools-only. The 24h window works on both endpoints, for sorting and for filtering.