### PR TITLE
Let token search filter on the 24h price change too

### DIFF
--- a/dexpaprika/tokens.go
+++ b/dexpaprika/tokens.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"fmt"
 	"net/http"
+	"strconv"
 	"strings"
 )
 
@@ -273,6 +274,14 @@ type TokenFilterOptions struct {
 	Txns24hMin    *int
 	CreatedAfter  string
 	CreatedBefore string
+
+	// The 24h window is the only price-change bound tokens/search honours, in
+	// percent. Negatives are meaningful: PriceChange24hMax of -20 finds tokens
+	// down at least a fifth on the day. The 6h, 1h and 5m bounds that
+	// PoolFilterOptions carries are absent here on purpose, because token rows
+	// have no such fields and the endpoint ignores those parameters.
+	PriceChange24hMin *float64
+	PriceChange24hMax *float64
 }
 
 // Filter returns tokens on a network filtered by volume, liquidity, FDV, transactions, and creation date.
@@ -328,6 +337,12 @@ func (s *TokensService) Filter(ctx context.Context, networkID string, opts *Toke
 		}
 		if opts.Txns24hMin != nil {
 			q.Add("txns_24h_min", fmt.Sprintf("%d", *opts.Txns24hMin))
+		}
+		if opts.PriceChange24hMin != nil {
+			q.Add("price_change_percentage_24h_min", strconv.FormatFloat(*opts.PriceChange24hMin, 'f', -1, 64))
+		}
+		if opts.PriceChange24hMax != nil {
+			q.Add("price_change_percentage_24h_max", strconv.FormatFloat(*opts.PriceChange24hMax, 'f', -1, 64))
 		}
 		if opts.CreatedAfter != "" {
 			q.Add("created_after", opts.CreatedAfter)

--- a/dexpaprika/tokens_test.go
+++ b/dexpaprika/tokens_test.go
@@ -2,6 +2,10 @@ package dexpaprika
 
 import (
 	"context"
+	"fmt"
+	"net/http"
+	"net/http/httptest"
+	"strings"
 	"testing"
 	"time"
 )
@@ -234,5 +238,49 @@ func TestTokens_ValidationErrors(t *testing.T) {
 	_, err = client.Tokens.GetPools(ctx, "ethereum", "", nil)
 	if err == nil || err.Error() != "token address is required" {
 		t.Errorf("Expected 'token address is required' error, got: %v", err)
+	}
+}
+
+// TestTokens_FilterSendsPriceChangeBounds covers the one price-change window
+// tokens/search actually honours. I originally wrote all four off as pool-only,
+// which was wrong: 24h works on both endpoints, only 6h, 1h and 5m are
+// pool-only. Checked live, and the bound is real rather than ignored:
+//
+//	no filter                          [95.7, -0.07, 0.23, -0.02, 0.4]
+//	price_change_percentage_24h_min=20 [95.7, 36.62, 15876.53, 22.96, 32.88]
+//	misspelled name                    [95.7, -0.07, 0.23, -0.02, 0.4]
+func TestTokens_FilterSendsPriceChangeBounds(t *testing.T) {
+	var got string
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		got = r.URL.RawQuery
+		w.Header().Set("Content-Type", "application/json")
+		fmt.Fprint(w, `{"results":[],"has_next_page":false}`)
+	}))
+	defer server.Close()
+
+	client := NewClient(
+		WithBaseURL(server.URL),
+		WithRetryConfig(0, 1*time.Millisecond, 1*time.Millisecond),
+	)
+	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+	defer cancel()
+
+	min24h := 20.0
+	max24h := -20.0
+	_, err := client.Tokens.Filter(ctx, "ethereum", &TokenFilterOptions{
+		PriceChange24hMin: &min24h,
+		PriceChange24hMax: &max24h,
+	})
+	if err != nil {
+		t.Fatalf("Filter returned error: %v", err)
+	}
+
+	for _, want := range []string{
+		"price_change_percentage_24h_min=20",
+		"price_change_percentage_24h_max=-20",
+	} {
+		if !strings.Contains(got, want) {
+			t.Errorf("query %q is missing %q", got, want)
+		}
 	}
 }


### PR DESCRIPTION
Follow-up to the price-change window PR that just merged. That one framed all four windows as pools-only. Right for the three short ones, wrong for 24h, and this closes the gap it left on the token side.

`/networks/{network}/tokens/search` honours `price_change_percentage_24h_min` and `_max`. Neither could be sent before this.

## Why it needed proving rather than trying

An unrecognised filter parameter does not fail. The endpoint answers `200` and returns the full unfiltered page, so "I sent it and got results" is not evidence of anything. The proof is the contrast, on ethereum:

```
no filter                                 [95.7, -0.07, 0.23, -0.02, 0.4]
price_change_percentage_24h_min=20        [95.7, 36.62, 15876.53, 22.96, 32.88]
price_change_percentage_24h_max=-20       [-99.41, -22.53, -56.11, -86.58, -27.49]
price_change_pct_24h_min=20 (misspelled)  [95.7, -0.07, 0.23, -0.02, 0.4]
price_change_percentage_6h_min=20         [95.7, -0.07, 0.23, -0.02, 0.4]
```

Line four is the control: a misspelled name returns the baseline row for row, which is what makes lines two and three mean something. Line five is why the short windows stay off the token side. Token rows carry no 6h, 1h or 5m field, so the bound is dropped, and ordering by any of the three is a `400`.

## Consistency

Every other surface in this rollout now carries the token 24h bounds: the Go, TypeScript, Python and PHP SDKs, the hosted MCP worker, and the CLI's `filter-tokens`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_016Zw5oLXk2fVxkVJvgqrc9j
